### PR TITLE
Simplify async talker example. Fix compile error.

### DIFF
--- a/examples/async_talker/main.rs
+++ b/examples/async_talker/main.rs
@@ -1,8 +1,4 @@
 use ros2_client::{Context, Node, NodeOptions};
-use rustdds::{
-  policy::{self, Deadline, Lifespan},
-  Duration, QosPolicies, QosPolicyBuilder,
-};
 use async_io::Timer;
 fn main() {
   // Here is a fixed path, so this example must be started from
@@ -10,13 +6,12 @@ fn main() {
   log4rs::init_file("examples/async_talker/log4rs.yaml", Default::default()).unwrap();
 
   let mut node = create_node();
-  let topic_qos = create_qos();
 
   let chatter_topic = node
     .create_topic(
       "/topic",
       String::from("std_msgs::msg::dds_::String_"),
-      &topic_qos,
+      &ros2_client::DEFAULT_PUBLISHER_QOS,
     )
     .unwrap();
   let chatter_publisher = node
@@ -36,25 +31,6 @@ fn main() {
       Timer::after(std::time::Duration::from_secs(2)).await;
     }
   });
-}
-fn create_qos() -> QosPolicies {
-  let service_qos: QosPolicies = {
-    QosPolicyBuilder::new()
-      .history(policy::History::KeepLast { depth: 10 })
-      .reliability(policy::Reliability::Reliable {
-        max_blocking_time: Duration::from_millis(100),
-      })
-      .durability(policy::Durability::Volatile)
-      .deadline(Deadline(Duration::INFINITE))
-      .lifespan(Lifespan {
-        duration: Duration::INFINITE,
-      })
-      .liveliness(policy::Liveliness::Automatic {
-        lease_duration: Duration::INFINITE,
-      })
-      .build()
-  };
-  service_qos
 }
 
 fn create_node() -> Node {

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@ use async_channel::Receiver;
 use log::{debug, error, info, trace, warn};
 use serde::{de::DeserializeOwned, Serialize};
 use rustdds::{
-  dds::{CreateError, CreateResult},
+  dds::{statusevents::DomainParticipantStatusEvent, CreateError, CreateResult},
   *,
 };
 
@@ -246,7 +246,7 @@ impl Node {
 
     let ros_discovery_stream = ros_discovery_reader.async_stream();
     let dds_status_listener = self.ros_context.domain_participant().status_listener();
-    let dds_status_stream = dds_status_listener.as_async_status_stream();
+    let dds_status_stream = dds_status_listener.as_async_stream();
     pin_mut!(ros_discovery_stream);
     pin_mut!(dds_status_stream);
 


### PR DESCRIPTION
Hi, I simplified the `async_talker` example following commit [87ff2c4](https://github.com/jhelovuo/ros2-client/commit/87ff2c4fe9d3759ea49824d19164a6bd6ca66780). I also found `node.rs` failed to compile and fixed it. 
I have run `prepare-for-commit.sh` before making this PR.