### PR TITLE
Update to RustDDS with `DeserializeSeed` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,10 @@ security = [
 
 [dependencies]
 
-# rustdds = {  path = "../RustDDS"  } # dev setting
+#  rustdds = {  path = "../RustDDS"  } # dev setting
 # rustdds = {   git = "https://github.com/jhelovuo/RustDDS.git" }
-rustdds = {  version = "~0.9.2"  } # release setting
+# rustdds = {  version = "~0.9.2"  } # release setting
+rustdds = { git = "https://github.com/dora-rs/RustDDS.git", branch = "deserialize-seed-2" }
 
 mio = "^0.6.23"
 mio-extras = "2.0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,8 @@ security = [
 [dependencies]
 
 #  rustdds = {  path = "../RustDDS"  } # dev setting
-# rustdds = {   git = "https://github.com/jhelovuo/RustDDS.git" }
+rustdds = {   git = "https://github.com/jhelovuo/RustDDS.git", branch = "deserialize-with-seed" }
 # rustdds = {  version = "~0.9.2"  } # release setting
-rustdds = { git = "https://github.com/dora-rs/RustDDS.git", branch = "deserialize-seed-2" }
 
 mio = "^0.6.23"
 mio-extras = "2.0.6"

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 //use mio::Evented;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::Serialize;
 use rustdds::{
   dds::CreateResult,
   no_key::{DeserializerAdapter, SerializerAdapter},
@@ -251,7 +251,7 @@ impl Context {
     qos: Option<QosPolicies>,
   ) -> dds::CreateResult<Subscription<M>>
   where
-    M: 'static + DeserializeOwned,
+    M: 'static,
   {
     let datareader = self
       .get_ros_default_subscriber()

--- a/src/node.rs
+++ b/src/node.rs
@@ -7,7 +7,7 @@ use futures::{pin_mut, stream::FusedStream, FutureExt, Stream, StreamExt};
 use async_channel::Receiver;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::Serialize;
 use rustdds::{dds::CreateError, dds::CreateResult, *};
 
 use crate::{
@@ -1146,7 +1146,7 @@ impl Node {
   /// * `topic` - Reference to topic created with `create_ros_topic`.
   /// * `qos` - Should take [QOS](../dds/qos/struct.QosPolicies.html) and use if
   ///   it's compatible with topics QOS. `None` indicates the use of Topics QOS.
-  pub fn create_subscription<D: DeserializeOwned + 'static>(
+  pub fn create_subscription<D: 'static>(
     &mut self,
     topic: &Topic,
     qos: Option<QosPolicies>,

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -110,7 +110,7 @@ where
 
   pub fn take_seed<'de, S>(&self, seed: S) -> ReadResult<Option<(M, MessageInfo)>>
   where
-    S: serde::de::DeserializeSeed<'de, Value = M>,
+    S: serde::de::DeserializeSeed<'de, Value = M> + Clone,
     M: 'static,
   {
     self.datareader.drain_read_notifications();

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -3,11 +3,12 @@ use std::io;
 use mio::{Evented, Poll, PollOpt, Ready, Token};
 use futures::{
   pin_mut,
-  stream::{FusedStream, StreamExt},
+  stream::{FusedStream, StreamExt}, Stream,
 };
 use rustdds::{
   dds::{ReadError, ReadResult, WriteResult},
   *,
+  serialization::CdrDeserializeSeedDecoder,
 };
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -94,16 +95,49 @@ impl<M: Serialize> Publisher<M> {
 ///
 /// Corresponds to a (simplified) [`DataReader`](rustdds::no_key::DataReader) in
 /// DDS
-pub struct Subscription<M: DeserializeOwned> {
+pub struct Subscription<M> {
   datareader: no_key::SimpleDataReaderCdr<M>,
 }
 
-impl<M: 'static + DeserializeOwned> Subscription<M> {
+impl<M> Subscription<M>
+where
+  M: 'static,
+{
   // These must be created from Node
   pub(crate) fn new(datareader: no_key::SimpleDataReaderCdr<M>) -> Subscription<M> {
     Subscription { datareader }
   }
 
+  pub fn take_seed<'de, S>(&self, seed: S) -> ReadResult<Option<(M, MessageInfo)>>
+  where
+    S: serde::de::DeserializeSeed<'de, Value = M>,
+    M: 'static,
+  {
+    self.datareader.drain_read_notifications();
+    let decoder = CdrDeserializeSeedDecoder::from(seed);
+    let ds: Option<no_key::DeserializedCacheChange<M>> =
+      self.datareader.try_take_one_with(decoder)?;
+    Ok(ds.map(dcc_to_value_and_messageinfo))
+  }
+
+  // Returns an async Stream of messages with MessageInfo metadata
+  pub fn async_stream_seed<'a, 'de, S>(
+    &'a self,
+    seed: S,
+  ) -> impl Stream<Item = ReadResult<(M, MessageInfo)>> + FusedStream + 'a
+  where
+    S: serde::de::DeserializeSeed<'de, Value = M> + Clone + 'a,
+    M: 'static,
+  {
+    let decoder = CdrDeserializeSeedDecoder::from(seed);
+    self
+      .datareader
+      .as_async_stream_with(decoder)
+      .map(|result| result.map(dcc_to_value_and_messageinfo))
+  }
+}
+
+impl<M: 'static + DeserializeOwned> Subscription<M> {
   pub fn take(&self) -> ReadResult<Option<(M, MessageInfo)>> {
     self.datareader.drain_read_notifications();
     let ds: Option<no_key::DeserializedCacheChange<M>> = self.datareader.try_take_one()?;
@@ -130,7 +164,12 @@ impl<M: 'static + DeserializeOwned> Subscription<M> {
       .as_async_stream()
       .map(|result| result.map(dcc_to_value_and_messageinfo))
   }
+}
 
+impl<M> Subscription<M>
+where
+  M: 'static,
+{
   pub fn guid(&self) -> rustdds::GUID {
     self.datareader.guid()
   }
@@ -159,10 +198,7 @@ impl<M: 'static + DeserializeOwned> Subscription<M> {
 
 // helper
 #[inline]
-fn dcc_to_value_and_messageinfo<M>(dcc: no_key::DeserializedCacheChange<M>) -> (M, MessageInfo)
-where
-  M: DeserializeOwned,
-{
+fn dcc_to_value_and_messageinfo<M>(dcc: no_key::DeserializedCacheChange<M>) -> (M, MessageInfo) {
   let mi = MessageInfo::from(&dcc);
   (dcc.into_value(), mi)
 }

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, marker::PhantomData};
 
 use mio::{Evented, Poll, PollOpt, Ready, Token};
 use futures::{
@@ -114,7 +114,7 @@ where
     M: 'static,
   {
     self.datareader.drain_read_notifications();
-    let decoder = CdrDeserializeSeedDecoder::from(seed);
+    let decoder = CdrDeserializeSeedDecoder::new(seed, PhantomData::<()>);
     let ds: Option<no_key::DeserializedCacheChange<M>> =
       self.datareader.try_take_one_with(decoder)?;
     Ok(ds.map(dcc_to_value_and_messageinfo))
@@ -129,7 +129,7 @@ where
     S: serde::de::DeserializeSeed<'de, Value = M> + Clone + 'a,
     M: 'static,
   {
-    let decoder = CdrDeserializeSeedDecoder::from(seed);
+    let decoder = CdrDeserializeSeedDecoder::new(seed, PhantomData::<()>);
     self
       .datareader
       .as_async_stream_with(decoder)

--- a/src/service/wrappers.rs
+++ b/src/service/wrappers.rs
@@ -334,12 +334,36 @@ impl<RW> ServiceDeserializerAdapter<RW> {
 
 impl<RW: Wrapper> no_key::DeserializerAdapter<RW> for ServiceDeserializerAdapter<RW> {
   type Error = ReadError;
+  type Deserialized = RW;
 
   fn supported_encodings() -> &'static [RepresentationIdentifier] {
     &Self::REPR_IDS
   }
 
-  fn from_bytes(input_bytes: &[u8], encoding: RepresentationIdentifier) -> ReadResult<RW> {
+  fn transform_deserialized(deserialized: Self::Deserialized) -> RW {
+    deserialized
+  }
+}
+
+impl<RW: Wrapper> no_key::DefaultDecoder<RW> for ServiceDeserializerAdapter<RW> {
+  type Decoder = WrapperDecoder;
+  const DECODER: Self::Decoder = WrapperDecoder;
+}
+
+#[derive(Clone)]
+pub struct WrapperDecoder;
+
+impl<RW> no_key::Decode<RW> for WrapperDecoder
+where
+  RW: Wrapper,
+{
+  type Error = ReadError;
+
+  fn decode_bytes(
+    self,
+    input_bytes: &[u8],
+    encoding: RepresentationIdentifier,
+  ) -> Result<RW, Self::Error> {
     Ok(RW::from_bytes_and_ri(input_bytes, encoding))
   }
 }

--- a/src/service/wrappers.rs
+++ b/src/service/wrappers.rs
@@ -334,14 +334,14 @@ impl<RW> ServiceDeserializerAdapter<RW> {
 
 impl<RW: Wrapper> no_key::DeserializerAdapter<RW> for ServiceDeserializerAdapter<RW> {
   type Error = ReadError;
-  type Deserialized = RW;
+  type Decoded = RW;
 
   fn supported_encodings() -> &'static [RepresentationIdentifier] {
     &Self::REPR_IDS
   }
 
-  fn transform_deserialized(deserialized: Self::Deserialized) -> RW {
-    deserialized
+  fn transform_decoded(decoded: Self::Decoded) -> RW {
+    decoded
   }
 }
 


### PR DESCRIPTION
Updates `ros2-client` to the RustDDS changes in https://github.com/jhelovuo/RustDDS/pull/313.

The main changes are:

- Update the RustDDS trait implementations for `ServiceDeserializerAdapter`
    - The `no_key::DeserializerAdapter` trait changed.
    - Provide a new `WrapperDecoder` and implement `DefaultDecoder`
- Remove some `DeserializeOwned` bounds that are no longer needed.
- Provide new `take_seed` and `async_stream_seed` methods on `Subscription` that support stateful deserialization using serde's `DeserializeSeed` trait.

This PR is marked as a draft as it should only be merged once https://github.com/jhelovuo/RustDDS/pull/313 is merged and released.