### PR TITLE
Remove unnecessary mutable reference in ActionClient

### DIFF
--- a/examples/turtle_teleop/main.rs
+++ b/examples/turtle_teleop/main.rs
@@ -354,7 +354,7 @@ fn ros2_loop(
     status_subscription: service_qos,
   };
 
-  let mut rotate_action_client = ros_node
+  let rotate_action_client = ros_node
     .create_action_client::<RotateAbsoluteAction>(
       ServiceMapping::Enhanced,
       &Name::new("/turtle1", "rotate_absolute").unwrap(),

--- a/src/action/client.rs
+++ b/src/action/client.rs
@@ -54,26 +54,24 @@ where
     &self.my_action_name
   }
 
-  pub fn goal_client(
-    &mut self,
-  ) -> &mut Client<AService<SendGoalRequest<A::GoalType>, SendGoalResponse>> {
-    &mut self.my_goal_client
+  pub fn goal_client(&self) -> &Client<AService<SendGoalRequest<A::GoalType>, SendGoalResponse>> {
+    &self.my_goal_client
   }
   pub fn cancel_client(
-    &mut self,
-  ) -> &mut Client<AService<action_msgs::CancelGoalRequest, action_msgs::CancelGoalResponse>> {
-    &mut self.my_cancel_client
+    &self,
+  ) -> &Client<AService<action_msgs::CancelGoalRequest, action_msgs::CancelGoalResponse>> {
+    &self.my_cancel_client
   }
   pub fn result_client(
-    &mut self,
-  ) -> &mut Client<AService<GetResultRequest, GetResultResponse<A::ResultType>>> {
-    &mut self.my_result_client
+    &self,
+  ) -> &Client<AService<GetResultRequest, GetResultResponse<A::ResultType>>> {
+    &self.my_result_client
   }
-  pub fn feedback_subscription(&mut self) -> &mut Subscription<FeedbackMessage<A::FeedbackType>> {
-    &mut self.my_feedback_subscription
+  pub fn feedback_subscription(&self) -> &Subscription<FeedbackMessage<A::FeedbackType>> {
+    &self.my_feedback_subscription
   }
-  pub fn status_subscription(&mut self) -> &mut Subscription<action_msgs::GoalStatusArray> {
-    &mut self.my_status_subscription
+  pub fn status_subscription(&self) -> &Subscription<action_msgs::GoalStatusArray> {
+    &self.my_status_subscription
   }
 
   /// Returns and id of the Request and id for the Goal.


### PR DESCRIPTION
Thanks for your nice crate.

Finding that to access the service or topic in the ActionClient, a mutable reference of ActionClient is required, I think it is totally unnecessary. It is almost impossible to modify them in other crate because most of the related methods are `pub(crate)` even private. Removing the &mut can make external design easier as well.