### PR TITLE
Zenoh support

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,21 @@
+# cargo-audit configuration (read by `cargo audit` / rustsec/audit-check).
+#
+# The advisories below are in TRANSITIVE dependencies pulled in only by the
+# optional `zenoh` feature (Zenoh's transport stack). They cannot be resolved
+# from this crate — they need an upstream Zenoh dependency bump — so they are
+# ignored here with justification and should be revisited when Zenoh updates.
+# The default `dds` build does not compile any of these crates.
+
+[advisories]
+ignore = [
+  # lz4_flex < 0.11.6: memory exposure when decompressing invalid LZ4 block
+  # data. Pulled transitively by `zenoh` (compression); `zenoh` pins the 0.10.x
+  # line, so no patched version is selectable until Zenoh upgrades. ros2-client
+  # never calls the affected block-decompress APIs directly.
+  "RUSTSEC-2026-0041",
+  # rsa 0.9.x: "Marvin" timing side-channel in RSA. Transitive via `zenoh`'s
+  # TLS stack. No patched release exists upstream at time of writing; only
+  # relevant to the optional `zenoh` feature and only in adversarial-timing
+  # network settings.
+  "RUSTSEC-2023-0071",
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,10 +2,11 @@ name: Security audit
 
 on:
   push:
-    paths: 
+    paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - '.github/workflows/audit.yml'
+      - '.cargo/audit.toml' # advisory ignore list (see file for rationale)
 
 permissions:
   issues: write

--- a/.github/workflows/tests-zenoh.yml
+++ b/.github/workflows/tests-zenoh.yml
@@ -25,6 +25,12 @@ jobs:
       - name: clippy (zenoh)
         run: cargo clippy --no-default-features --features zenoh --lib --bins -- -D warnings
 
+      # The zenoh-backend example must compile (and lint clean). The DDS
+      # examples are gated on the `dds` feature (Cargo.toml `required-features`)
+      # and are skipped under this feature set.
+      - name: clippy examples (zenoh)
+        run: cargo clippy --no-default-features --features zenoh --examples -- -D warnings
+
       # `--lib` only: the crate-level doctest exercises the DDS API and is not
       # meant to compile under the zenoh backend. Serial to keep session ports
       # from contending.

--- a/.github/workflows/tests-zenoh.yml
+++ b/.github/workflows/tests-zenoh.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+name: CI / Zenoh backend
+
+permissions: read-all
+
+jobs:
+
+  build-zenoh:
+    name: build & test (zenoh feature)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      # The Zenoh backend is built with the DDS default turned off.
+      - name: check (zenoh)
+        run: cargo check --no-default-features --features zenoh
+
+      - name: clippy (zenoh)
+        run: cargo clippy --no-default-features --features zenoh --lib --bins -- -D warnings
+
+      # `--lib` only: the crate-level doctest exercises the DDS API and is not
+      # meant to compile under the zenoh backend. Serial to keep session ports
+      # from contending.
+      - name: test (zenoh, lib)
+        run: cargo test --no-default-features --features zenoh --lib -- --test-threads=1
+
+      # Guard the feature exclusivity: the DDS backend must also build when
+      # selected explicitly with default features off.
+      - name: check (dds, explicit)
+        run: cargo check --no-default-features --features dds

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,14 @@ keywords = ["network","protocol","dds","rtps"]
 license = "Apache-2.0"
 homepage = "https://atostek.com/en/products/rustdds/"  
 repository = "https://github.com/Atostek/ros2-client/"
-categories = ["network-programming", "science::robotics"] 
+categories = ["network-programming", "science::robotics"]
+
+# Examples are declared explicitly (below) rather than auto-discovered, so each
+# can carry `required-features`. The bundled examples use the DDS backend API;
+# they are gated on `dds` so a `--no-default-features --features zenoh` build of
+# `--examples` skips them instead of failing. The `zenoh` backend has its own
+# example, `zenoh_demo`.
+autoexamples = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -128,3 +135,106 @@ smol = "2.0"
 async-io = "2.2.0"
 async-ctrlc = "1.2"
 tokio = { version = "1", features=["rt", "macros", "time", "sync"]}
+
+
+# ---------------------------------------------------------------------------
+# Examples
+# ---------------------------------------------------------------------------
+# DDS-backend examples (the default build). Gated on `dds` so they are skipped
+# on a `zenoh` build rather than failing to compile.
+
+[[example]]
+name = "talker"
+path = "examples/talker/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "listener"
+path = "examples/listener/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "async_talker"
+path = "examples/async_talker/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "async_listener"
+path = "examples/async_listener/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "async_smart_talker"
+path = "examples/async_smart_talker/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "async_service_client"
+path = "examples/async_service_client/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "async_service_server"
+path = "examples/async_service_server/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "ros2_service_client"
+path = "examples/ros2_service_client/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "ros2_service_server"
+path = "examples/ros2_service_server/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "minimal_action_client"
+path = "examples/minimal_action_client/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "minimal_action_server"
+path = "examples/minimal_action_server/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "concurrent_action_server"
+path = "examples/concurrent_action_server/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "client_get_parameters"
+path = "examples/client_get_parameters/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "client_list_parameters"
+path = "examples/client_list_parameters/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "discovery_listener"
+path = "examples/discovery_listener/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "time_broadcaster"
+path = "examples/time_broadcaster/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "time_reporter"
+path = "examples/time_reporter/main.rs"
+required-features = ["dds"]
+
+[[example]]
+name = "turtle_teleop"
+path = "examples/turtle_teleop/main.rs"
+required-features = ["dds"]
+
+# Zenoh-backend example.
+[[example]]
+name = "zenoh_demo"
+path = "examples/zenoh_demo/main.rs"
+required-features = ["zenoh"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ categories = ["network-programming", "science::robotics"]
 #   cargo build --no-default-features --features zenoh
 # ---------------------------------------------------------------------------
 dds   = ["dep:rustdds"]
-zenoh = ["dep:zenoh", "dep:zenoh-ext"]
+zenoh = ["dep:zenoh", "dep:zenoh-ext", "dep:cdr-encoding", "dep:byteorder"]
 
 # declare the existence of "security" feature (Secure ROS 2 support).
 # Security is a DDS-only capability (RustDDS security); it implies `dds`.
@@ -79,6 +79,10 @@ rustdds = { version = "0.13", optional = true } # release setting
 # (see docs/zenoh_study/research/zenoh_api.md).
 zenoh     = { version = "1", optional = true, features = ["unstable"] }
 zenoh-ext = { version = "1", optional = true, features = ["unstable"] }
+# Standalone CDR (de)serialization for the Zenoh backend (the DDS backend gets
+# CDR via RustDDS). Same author as RustDDS, so byte output matches (ADR-0003).
+cdr-encoding = { version = "0.10", optional = true }
+byteorder = { version = "1", optional = true } # CDR byte-order selector
 
 mio = "^0.6.23"
 mio-extras = "2.0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,11 @@ tracing = "0.1.41"
 # dependency is unconditional (it is tiny and pure-Rust) to keep the wire-format
 # modules unit-testable on any build.
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+# REP-2016 `RIHS01_…` type hashes are SHA-256 over a canonical JSON type
+# description (docs/decisions/0007). Like the GID hashing above, this is
+# backend-neutral spec code, so the (pure-Rust) dependency is unconditional to
+# keep the type-hash module unit-testable on any build.
+sha2 = "0.10"
 
 [dev-dependencies]
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,12 @@ widestring = "1.0" # msggen
 libc = "0.2.153"
 tracing = "0.1.41"
 
+# Entity GID for the Zenoh backend is XXH3-128 of the liveliness key
+# (docs/decisions/0008). The algorithm is backend-neutral spec code, so the
+# dependency is unconditional (it is tiny and pure-Rust) to keep the wire-format
+# modules unit-testable on any build.
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
+
 [dev-dependencies]
 log = "0.4"
 pretty_env_logger = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,23 @@ categories = ["network-programming", "science::robotics"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-# declare the existence of "security" feature (Secure ROS 2 support)
-security = [ 
-  "rustdds/security" # Requires "security" in RustDDS also
+
+# ---------------------------------------------------------------------------
+# Middleware backend selection (mutually exclusive). See
+# docs/decisions/0002-dual-backend-compile-time-feature-selection.md
+#
+# Exactly one of `dds` (default) or `zenoh` must be enabled; lib.rs emits a
+# compile_error! if both or neither are active. Build the Zenoh backend with:
+#   cargo build --no-default-features --features zenoh
+# ---------------------------------------------------------------------------
+dds   = ["dep:rustdds"]
+zenoh = ["dep:zenoh", "dep:zenoh-ext"]
+
+# declare the existence of "security" feature (Secure ROS 2 support).
+# Security is a DDS-only capability (RustDDS security); it implies `dds`.
+security = [
+  "dds",
+  "rustdds/security", # Requires "security" in RustDDS also
 ]
 
 # ROS 2 distribution selection.
@@ -48,14 +62,23 @@ jazzy    = ["iron"]
 kilted   = ["jazzy"]
 lyrical  = ["kilted"]
 
-default = ["jazzy"]
+# Default build: the DDS backend on the jazzy distribution.
+default = ["dds", "jazzy"]
 
 
 [dependencies]
 
+# RustDDS backend (feature `dds`). Optional so the `zenoh` backend can be built
+# without pulling RustDDS in.
 # rustdds = {  path = "../RustDDS"  } # dev setting
 # rustdds = {   git = "https://github.com/Atostek/RustDDS.git" }
-rustdds = {  version = "0.13"  } # release setting
+rustdds = { version = "0.13", optional = true } # release setting
+
+# Zenoh backend (feature `zenoh`). Optional; only compiled when `zenoh` is
+# enabled. `unstable` is required for liveliness, advanced pub/sub and matching
+# (see docs/zenoh_study/research/zenoh_api.md).
+zenoh     = { version = "1", optional = true, features = ["unstable"] }
+zenoh-ext = { version = "1", optional = true, features = ["unstable"] }
 
 mio = "^0.6.23"
 mio-extras = "2.0.6"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,65 @@ Please see the included examples on how to use the various features.
 * Message generation: from `.msg` to `.rs`- experimental
 * ROS 2 Security - experimental
 
+## Middleware backends: DDS and Zenoh
+
+`ros2-client` can talk to ROS 2 over either of two middleware backends,
+selected at compile time by **mutually exclusive** Cargo features:
+
+* **`dds`** (default) — communicates via [RustDDS](https://github.com/jhelovuo/RustDDS),
+  interoperating with ROS 2's default DDS RMWs (`rmw_fastrtps`, `rmw_cyclonedds`, …).
+* **`zenoh`** — communicates via [Zenoh](https://zenoh.io/), mirroring the wire
+  protocol of the official [`rmw_zenoh`](https://github.com/ros2/rmw_zenoh)
+  middleware, so it interoperates with ROS 2 nodes running `rmw_zenoh`.
+
+Exactly one backend must be enabled; the build emits a `compile_error!` if both
+or neither are active. The default build uses `dds`. Build the Zenoh backend
+with:
+
+```console
+cargo build --no-default-features --features zenoh
+```
+
+Run the bundled Zenoh example (a self-contained talker + listener over
+loopback):
+
+```console
+cargo run --no-default-features --features zenoh --example zenoh_demo
+```
+
+### Zenoh router requirement
+
+Like `rmw_zenoh`, the Zenoh backend discovers peers and exchanges the ROS graph
+through Zenoh's infrastructure. For anything beyond a single process you
+normally run a **Zenoh router** (`zenohd`), exactly as `rmw_zenoh` does, or
+configure explicit peer `connect`/`listen` endpoints. The in-process examples
+and tests connect two peers directly over loopback, so they need no router. See
+[`docs/decisions/0009-zenoh-router-and-config.md`](docs/decisions/0009-zenoh-router-and-config.md)
+for configuration details.
+
+### Feature support on the Zenoh backend
+
+| Capability | Zenoh backend | Notes |
+| ---------- | :-----------: | ----- |
+| Topics (publish/subscribe) | ✅ | CDR payload + `(seq, timestamp, gid)` attachment, per `rmw_zenoh` |
+| Services (client/server)   | ✅ | Zenoh queryable / get |
+| Actions                    | ✅ | Composed of services + a feedback topic, as in ROS 2 |
+| Parameters + `parameter_events` | ✅ | Six `rcl_interfaces` services + events topic |
+| `rosout` logging           | ✅ | `/rosout` publisher + optional reader |
+| Discovery / ROS graph      | ✅ | Zenoh liveliness tokens + a graph cache |
+| QoS                        | ⚠️ | Backend-neutral profile carried in liveliness keys; not all policies enforced |
+| ROS 2 Security             | ❌ | DDS-only (RustDDS security) |
+| Message generation (`msggen`) | ✅ | Backend-neutral |
+
+The design, the `rmw_zenoh` mapping, and the wire-format details are documented
+under [`docs/zenoh_study/`](docs/zenoh_study/); the design decisions are recorded
+under [`docs/decisions/`](docs/decisions/).
+
+> **Type hashes (send direction):** REP-2016 `RIHS01_…` type hashes are emitted
+> from a table of known interop types; types outside that table use a wildcard
+> on receive and a placeholder on send. Computing hashes from parsed IDL is a
+> tracked post-MVP follow-up (ADR-0007).
+
 ## ROS 2 Releases Compatibility
 
 This is what is expected to work. There are no routine tests against older releases.
@@ -64,6 +123,8 @@ distribution with, e.g., `cargo build --no-default-features --features humble`
 Please see [test results](interop/results) for details.  
 
 ## Version 0.10
+* Experimental **Zenoh** middleware backend (Cargo feature `zenoh`), mirroring
+  `rmw_zenoh`. See "Middleware backends: DDS and Zenoh" above.
 * Add interoperability tests and results.
 * ROS 2 distribution selection via a feature (`galactic` .. `lyrical`; default `jazzy`). 
 * `Context` now checks the `ROS_DISTRO` environment variable against the compiled distribution.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ for configuration details.
 
 The design, the `rmw_zenoh` mapping, and the wire-format details are documented
 under [`docs/zenoh_study/`](docs/zenoh_study/); the design decisions are recorded
-under [`docs/decisions/`](docs/decisions/).
+under [`docs/decisions/`](docs/decisions/). To validate interoperability against
+a real ROS 2 + `rmw_zenoh` stack, follow
+[`docs/zenoh_study/interop_runbook.md`](docs/zenoh_study/interop_runbook.md).
 
 > **Type hashes (send direction):** REP-2016 `RIHS01_…` type hashes are emitted
 > from a table of known interop types; types outside that table use a wildcard

--- a/docs/decisions/0001-record-architecture-decisions.md
+++ b/docs/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,28 @@
+# 1. Record architecture decisions
+
+- Status: accepted
+- Date: 2026-07-07
+
+## Context
+
+Adding a Zenoh backend to `ros2-client` (issue #71) is a large, multi-phase
+change with several irreversible design choices and compromises (feature
+architecture, public-API changes, wire-format interop trade-offs). The
+maintainer asked that "every compromise / design decision" be compiled into a
+reviewable set of records.
+
+## Decision
+
+We keep lightweight Architecture Decision Records (ADRs) in `docs/decisions/`,
+one file per decision, numbered sequentially, in a MADR-lite format
+(Context / Decision / Consequences). Each substantive design choice or
+compromise made while implementing the Zenoh backend gets an ADR. The technical
+rationale lives in `docs/zenoh_study/`; the ADRs capture the *decisions* and
+their trade-offs so they can be reviewed independently of the code.
+
+## Consequences
+
+- Reviewers can audit decisions without reading every diff.
+- ADRs are append-only; a later decision that reverses an earlier one adds a new
+  record and marks the old one superseded, rather than editing history.
+- Numbering is global across the project, not per-feature.

--- a/docs/decisions/0002-dual-backend-compile-time-feature-selection.md
+++ b/docs/decisions/0002-dual-backend-compile-time-feature-selection.md
@@ -1,0 +1,43 @@
+# 2. Dual backend via compile-time feature selection
+
+- Status: accepted
+- Date: 2026-07-07
+- Relates to: issue #71, `docs/zenoh_study/refactoring_plan.md`
+
+## Context
+
+`ros2-client` must support two middlewares — RustDDS (today) and Zenoh (new) —
+that are never used together in one build. Issue #71 proposes a default `dds`
+feature and an opt-in, **mutually exclusive** `zenoh` feature. The maintainer
+explicitly wants to avoid broad renames/refactoring and keep the change minimal.
+
+Two designs were considered:
+
+- **A. Runtime trait-object abstraction** (`trait Middleware` with associated
+  entity types; `Context`/`Node` generic over it).
+- **B. Compile-time selection** via `#[cfg(feature = "dds")]` /
+  `#[cfg(feature = "zenoh")]`, one non-generic public API, backend-specific
+  internals, plus a few owned public types.
+
+## Decision
+
+Adopt **B, compile-time feature selection**.
+
+- `default = ["dds"]`; `zenoh` is opt-in. A `compile_error!` fires if both or
+  neither backend feature is enabled.
+- All `rustdds` dependencies and code are gated behind `dds`; `zenoh`/`zenoh-ext`
+  are optional deps gated behind `zenoh`.
+- The DDS code path stays byte-for-byte as-is; Zenoh support is additive
+  (`#[cfg]` branches in `context.rs`/`node.rs`/`pubsub.rs`/`service/*` plus new
+  `src/zenoh_backend/*` modules).
+
+## Consequences
+
+- **Pro:** matches the mutually-exclusive-feature reality; zero runtime cost; no
+  generics threaded through the public API; the DDS path is untouched and its
+  tests keep passing; smallest possible churn.
+- **Con:** the two backends can't coexist in a single binary (acceptable —
+  that's the requirement). `#[cfg]` duplication in a few files. Documentation and
+  CI must cover both feature configurations (added to the CI matrix).
+- Because the backends are exclusive, no `dyn`/vtable abstraction is warranted;
+  shared behaviour is expressed as ordinary functions/types selected by `cfg`.

--- a/docs/decisions/0003-reuse-cdr-serialization.md
+++ b/docs/decisions/0003-reuse-cdr-serialization.md
@@ -1,0 +1,33 @@
+# 3. Reuse CDR serialization via `cdr-encoding`
+
+- Status: accepted
+- Date: 2026-07-07
+
+## Context
+
+Over DDS, messages are CDR-encoded through RustDDS writer/reader adapters. A
+Zenoh backend has no DataWriter/Reader but must produce **byte-identical** CDR
+payloads (including the 4-byte CDR encapsulation header) because `rmw_zenoh`
+carries the same CDR bytes as the Zenoh payload.
+
+## Decision
+
+Serialize/deserialize messages for the Zenoh path with the standalone
+[`cdr-encoding`](https://lib.rs/crates/cdr-encoding) crate
+(`to_vec::<M, LittleEndian>()` / `from_bytes::<M, LittleEndian>()`), and prepend
+the 4-byte encapsulation header (`00 01 00 00` for CDR_LE) via a small shared
+helper. `cdr-encoding` is already a transitive dependency and is authored by the
+RustDDS author, maximising the chance of byte parity.
+
+A unit test (Tier A7) pins the encapsulation-header handling and a first live
+pub/sub round-trip confirms header presence/duplication.
+
+## Consequences
+
+- **Pro:** no need to pull RustDDS under the `zenoh` feature; the same serde
+  `Message` types work unchanged; minimal new code.
+- **Con:** a dependency on `cdr-encoding` matching RustDDS's CDR output exactly —
+  guarded by unit tests and interop tests. If a discrepancy appears (e.g. header
+  emitted by `to_vec` vs added by us), the helper is the single place to fix it.
+- XCDR2/`RIHS`-driven type support is out of scope; plain CDR (XCDR1) only, which
+  is what the current DDS path and the interop targets use.

--- a/docs/decisions/0004-owned-public-types.md
+++ b/docs/decisions/0004-owned-public-types.md
@@ -1,0 +1,43 @@
+# 4. Introduce owned public types to decouple from RustDDS
+
+- Status: accepted
+- Date: 2026-07-07
+
+## Context
+
+RustDDS types appear in `ros2-client`'s public API: `QosPolicies`/
+`QosPolicyBuilder`/`policy::*`, `Timestamp`, `GUID`/`Gid`, `RmwRequestId`
+(≡ `SampleIdentity`), `MessageInfo` fields, `NodeEvent::DDS(...)`, and the
+`CreateError`/`ReadError`/`WriteError` families — all re-exported via `ros2::`.
+Under the `zenoh` feature we cannot depend on `rustdds` just to name these types,
+and several have no clean Zenoh equivalent.
+
+## Decision
+
+Introduce a small set of **owned** types used by both backends:
+
+- `qos::QosProfile` — the ROS 2 QoS profile (reliability, durability, history,
+  depth, deadline, lifespan, liveliness, lease). Under `dds`, `From`/`Into`
+  `rustdds::QosPolicies`; under `zenoh`, drives pub/sub options and the compact
+  `<qos>` liveliness encoding.
+- an owned timestamp for message/metadata fields (reusing `builtin_interfaces::
+  Time`/`ROSTime` where natural).
+- owned `error` enums, wrapping the backend error in a `#[cfg]`-gated variant.
+- a backend-neutral graph `NodeEvent`; `NodeEvent::DDS(...)` remains `dds`-only
+  and is deprecated.
+
+To honour the "minimal churn" constraint, keep the `ros2::` names as
+aliases/re-exports so existing examples and downstream code compile unchanged on
+the default `dds` build. `RmwRequestId` and `Gid` keep their shape (16-byte id +
+seq) but change provenance under `zenoh`.
+
+## Consequences
+
+- **Pro:** the public API stops *requiring* a RustDDS type for common use; both
+  backends share one surface; DDS users see minimal or no changes.
+- **Con:** a real (if contained) API evolution — the largest single change is
+  QoS. Conversions add code. Some rarely-used DDS-specific knobs
+  (`max_blocking_time`, `Ownership`) are not represented in `QosProfile` and are
+  either mapped to sensible DDS defaults or exposed only on the `dds` build.
+- This is the crux of "some DDS abstractions won't stand the transition, so we
+  use ROS 2 abstractions to replace them" from the task brief.

--- a/docs/decisions/0005-discovery-via-liveliness-tokens.md
+++ b/docs/decisions/0005-discovery-via-liveliness-tokens.md
@@ -1,0 +1,40 @@
+# 5. Discovery via Zenoh liveliness tokens + graph cache
+
+- Status: accepted
+- Date: 2026-07-07
+
+## Context
+
+`ros2-client` discovers the ROS graph two ways: RTPS reader/writer matching
+(`DomainParticipantStatusEvent`) driving `wait_for_*` and entity counts, and the
+`ros_discovery_info` data topic (`rmw_dds_common::ParticipantEntitiesInfo`)
+assembling the node/topic graph. Neither exists over Zenoh.
+
+`rmw_zenoh` instead declares a **liveliness token** per entity whose key encodes
+all metadata (`@ros2_lv/<domain>/<zid>/<nid>/<eid>/<kind>/…/<name>/<type>/<hash>/
+<qos>`), and builds a **graph cache** from a liveliness subscriber on
+`@ros2_lv/<domain>/**` plus an initial `liveliness_get`.
+
+## Decision
+
+Implement Zenoh discovery exactly per `rmw_zenoh`:
+
+- Each entity (node `NN`, publisher `MP`, subscription `MS`, service server `SS`,
+  service client `SC`) declares a liveliness token with the ground-truth key
+  format (name mangling `/`→`%`, empty→`%`; compact `<qos>` encoding).
+- The context declares a liveliness subscriber on `@ros2_lv/<domain>/**` and runs
+  an initial `liveliness().get()` to seed a graph cache; PUT/DELETE keep it live.
+- `wait_for_reader/writer` and `get_publisher/subscription_count` are
+  reimplemented over the cache, matching by name + type (hash treated liberally,
+  see ADR-0007), instead of GUID matching.
+- A backend-neutral `NodeEvent`/graph-event type is emitted (ADR-0004).
+
+## Consequences
+
+- **Pro:** full interop graph introspection (`ros2 node/topic/service list`),
+  matching the official design.
+- **Con:** a substantial new module (key build/parse + cache); the semantics of
+  "matched count" differ subtly from RTPS matching (cache-based, name/type keyed).
+  `NodeEvent::DDS` is deprecated/`dds`-only.
+- The `ros_discovery_info` topic and `DomainParticipantStatusEvent` are not used
+  under `zenoh`.

--- a/docs/decisions/0006-services-over-queryable-get.md
+++ b/docs/decisions/0006-services-over-queryable-get.md
@@ -1,0 +1,46 @@
+# 6. Services over Zenoh queryable/get; `ServiceMapping` is a DDS-only concept
+
+- Status: accepted
+- Date: 2026-07-07
+
+## Context
+
+`ros2-client` services use request (`rq/…Request`) and reply (`rr/…Reply`) DDS
+topics, with correlation via `RmwRequestId` (≡ RTPS `SampleIdentity` =
+`GUID`+`SequenceNumber`). Three `ServiceMapping`s (Basic/Enhanced/Cyclone) encode
+this differently on the wire; `Enhanced` (the default, used by parameter
+services) relies on RTPS **inline-QoS `related_sample_identity`**, which has no
+Zenoh equivalent.
+
+`rmw_zenoh` implements services with a Zenoh **queryable** (server) and
+**querier/get** (client): request/response ride the query/reply channel, and
+correlation uses the message **attachment** `(seq, ts, client_gid)`. The server
+keys pending queries by `hash(client_gid) → seq` and echoes seq+gid in the reply.
+
+## Decision
+
+Under `zenoh`, implement services with queryable/get exactly as `rmw_zenoh` does:
+
+- `Server`: `declare_queryable(key).complete(true)`, a pending-query map keyed by
+  `hash(client_gid) → sequence_number`, replies via `query.reply(...)` echoing
+  the request's seq + client gid and a fresh timestamp.
+- `Client`: `declare_querier(key)`/`get` with `target = ALL_COMPLETE`,
+  `consolidation = None`; a per-client monotonic sequence number (from 1);
+  attachment `(seq, ts, client_gid)`; correlate replies by the echoed seq.
+- The public `Client`/`Server` API and `RmwRequestId` shape are preserved, but
+  `writer_guid` becomes the client **entity GID** and `sequence_number` a
+  client-local counter.
+- `ServiceMapping` becomes a **no-op** under `zenoh` (Zenoh has exactly one
+  mapping). The type is kept for API compatibility and documented as `dds`-only;
+  the parameter services stop caring which mapping is requested.
+- `get_result` action services get an effectively infinite querier timeout
+  (key intersects `**/_action/get_result/**`).
+
+## Consequences
+
+- **Pro:** correct, interoperable services without RTPS inline QoS; one code path
+  instead of three mappings; actions and parameters inherit it for free.
+- **Con:** `ServiceMapping` selection is silently ignored under `zenoh` (a
+  documented compromise). `RmwRequestId`'s field meaning changes across backends.
+- Correlation now lives entirely in the attachment (payload-adjacent), which is
+  simpler and matches the ground truth.

--- a/docs/decisions/0007-type-hash-interop-strategy.md
+++ b/docs/decisions/0007-type-hash-interop-strategy.md
@@ -1,0 +1,52 @@
+# 7. Type-hash (REP-2016) interop strategy
+
+- Status: accepted
+- Date: 2026-07-07
+- Relates to: `docs/zenoh_study/feature_map.md` §11
+
+## Context
+
+`rmw_zenoh` key expressions and liveliness tokens include a REP-2016 type hash
+(`RIHS01_<64 hex>`), a SHA-256 over a canonical JSON description of the message
+type. Two Zenoh entities match only if **name AND type AND hash** agree.
+`ros2-client` is a generic serde client and computes **no** type hash today;
+computing a correct RIHS01 requires the full IDL type description (all nested
+fields), which the crate does not generally have at hand.
+
+Without the correct hash:
+- a `ros2-client` **subscriber/queryable** with a concrete-hash key won't receive
+  from a C++ publisher that uses the real hash;
+- a `ros2-client` **publisher** with a wrong/placeholder hash won't be received by
+  a C++ subscriber that subscribes to the real-hash key.
+
+`ros2-client`↔`ros2-client` works with any consistently-used placeholder.
+
+## Decision
+
+A layered strategy, MVP = (a) + (b):
+
+- **(a) Liberal receive.** Subscribers and queryables declare their key with a
+  wildcard (`*`/`**`) in the type-hash position, so they receive from **any**
+  publisher/client regardless of hash. This fixes the receive direction against
+  real ROS 2 immediately and is legal because Zenoh subscriber keys may contain
+  wildcards.
+- **(b) Known-types hash table.** For the send direction to C++ peers, ship a
+  small table of correct RIHS01 hashes for the common interop types
+  (`std_msgs/String`, `example_interfaces/srv/AddTwoInts`,
+  `action_tutorials_interfaces/action/Fibonacci`, `geometry_msgs/msg/Twist`, …),
+  and expose an API to supply a hash explicitly per topic/type. When a type is
+  unknown, fall back to a wildcard-or-placeholder and log that send-direction
+  interop with C++ peers may not match.
+- **(c) Future: compute RIHS01 from parsed `.msg`/`.srv`/`.action` IDL** in
+  `msggen`. Tracked as a follow-up issue, not required for MVP.
+
+## Consequences
+
+- **Pro:** interop works today for the receive direction universally and for the
+  send direction on the common types, without building a full IDL hasher.
+- **Con:** send-direction interop with C++ peers is limited to known types until
+  (c) lands; wildcard-receive slightly weakens type-safety at the transport layer
+  (mitigated by the type name still being in the key and CDR deserialization
+  failing loudly on a true mismatch).
+- The hash table must be kept in sync with upstream type definitions; a test
+  compares a few entries against values observed from a live `rmw_zenoh` peer.

--- a/docs/decisions/0007-type-hash-interop-strategy.md
+++ b/docs/decisions/0007-type-hash-interop-strategy.md
@@ -40,6 +40,28 @@ A layered strategy, MVP = (a) + (b):
 - **(c) Future: compute RIHS01 from parsed `.msg`/`.srv`/`.action` IDL** in
   `msggen`. Tracked as a follow-up issue, not required for MVP.
 
+## Update: RIHS01 computation implemented
+
+The core REP-2016 computation for (c) now exists in
+`src/zenoh_backend/type_description.rs`: a backend-neutral, from-scratch
+implementation of `rosidl_generator_type_description::calculate_type_hash`
+(the `FieldType` id scheme, the canonical hashable JSON — struct-order keys,
+`", "`/`": "` separators, `default_value` stripped, referenced types sorted by
+name — and `RIHS01_` + SHA-256). It reproduces the published hashes of
+`std_msgs/msg/String` and `example_interfaces/srv/AddTwoInts` byte-exactly
+(services compose a synthetic top type over `request_message`/`response_message`/
+`event_message` plus the transitive closure), and those values are cross-checked
+against the known-types table so the two can never silently diverge.
+
+What remains for (c) is the *pipeline* work, not the algorithm: teaching
+`msggen` to build a `TypeDescription` for each generated type by resolving the
+transitive closure of nested types across packages (and pinning a distro's
+builtin definitions, e.g. `service_msgs/ServiceEventInfo`, whose `client_gid`
+field type changed between distros and changes the hash), then emitting the
+computed hash as a generated constant the Zenoh backend can use directly. Until
+then, the send direction still relies on the known-types table for types not
+generated with a hash.
+
 ## Consequences
 
 - **Pro:** interop works today for the receive direction universally and for the

--- a/docs/decisions/0008-gid-and-attachment-byte-parity.md
+++ b/docs/decisions/0008-gid-and-attachment-byte-parity.md
@@ -1,0 +1,39 @@
+# 8. GID via XXH3-128 and attachment byte parity
+
+- Status: accepted
+- Date: 2026-07-07
+
+## Context
+
+For Zenoh interop, two byte-level formats must match `rmw_zenoh` exactly:
+
+1. **GID** — `rmw_zenoh` derives the 16-byte entity GID as the 128-bit XXH3 hash
+   of the entity's liveliness key string: `gid[0..8] = low64`,
+   `gid[8..16] = high64`, each in host (little-endian) order. It uses a
+   self-contained "simplified" XXH3-128 for cross-version stability.
+2. **Attachment** — every put/request/response carries a `zenoh-ext`-serialized
+   tuple `(i64 sequence, i64 source_timestamp_ns, [u8;16] source_gid)`. The
+   `zenoh-ext` serializer length-prefixes the array, so the layout is
+   `8B seq | 8B ts | 1B len(=16) | 16B gid`, not a naive concatenation.
+
+## Decision
+
+- Compute the Zenoh GID as XXH3-128 (seed 0) of the liveliness key string using
+  the [`xxhash-rust`](https://crates.io/crates/xxhash-rust) `xxh3` implementation,
+  writing `low64` then `high64` as little-endian bytes. A unit test pins the
+  result against a known vector derived from a sample key.
+- Serialize/deserialize the attachment with `zenoh_ext::z_serialize` /
+  `z_deserialize` (the Rust counterpart of zenoh-cpp `ext::Serializer`) to get the
+  length-prefixed framing for free, rather than hand-rolling bytes. A unit test
+  pins the exact byte layout.
+- Both are validated by live interop (a `ros2-client` node and a C++ peer must see
+  each other's GIDs and correlate service replies).
+
+## Consequences
+
+- **Pro:** byte-for-byte interop with `rmw_zenoh`; correlation and graph identity
+  work across the C++/Rust boundary.
+- **Con:** depends on `xxhash-rust`'s XXH3-128 matching `rmw_zenoh`'s "simplified"
+  implementation and on `zenoh-ext`'s Rust/C++ serializers agreeing. Both are
+  guarded by unit + interop tests; if a mismatch is found, the isolated
+  `gid`/`attachment` modules are the single place to correct it.

--- a/docs/decisions/0009-zenoh-router-and-config.md
+++ b/docs/decisions/0009-zenoh-router-and-config.md
@@ -1,0 +1,39 @@
+# 9. Zenoh router requirement and session configuration
+
+- Status: accepted
+- Date: 2026-07-07
+
+## Context
+
+`rmw_zenoh` runs each ROS process as a Zenoh **peer** that, by default, connects
+to a local Zenoh **router** (`zenohd`) which gossips peer locators so peers form
+direct p2p connections. Discovery relies on the router unless UDP multicast
+scouting is enabled (disabled by default to avoid cross-robot interference).
+Configuration comes from JSON5 files selected by `ZENOH_SESSION_CONFIG_URI` /
+`ZENOH_ROUTER_CONFIG_URI`, with `ZENOH_CONFIG_OVERRIDE` for inline overrides.
+
+## Decision
+
+- `Context` opens one `zenoh::Session` in **peer** mode with defaults mirroring
+  `DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5` (connect `tcp/localhost:7447`, listen
+  `tcp/localhost:0`, gossip on, multicast off, timestamping on). We bundle an
+  equivalent default JSON5 and honour `ZENOH_SESSION_CONFIG_URI` and
+  `ZENOH_CONFIG_OVERRIDE` so `ros2-client` obeys the same environment as
+  `rmw_zenoh`.
+- A running `zenohd`/`rmw_zenohd` router is **required by default**, documented in
+  the README. Initialization tolerates a missing router (log + periodic retry,
+  like `rmw_zenoh`) and connects when one appears.
+- `ContextOptions` keeps `domain_id` (used as the key-expression prefix, not a
+  transport setting) and gains zenoh-only config knobs (config path/overrides).
+- **Testing compromise:** hermetic in-process tests (Tier B) connect two peers
+  **directly** via explicit connect/listen endpoints, so they need **no** router.
+  Real-ROS-2 interop tests (Tier C) launch `rmw_zenohd`.
+
+## Consequences
+
+- **Pro:** drop-in compatibility with the `rmw_zenoh` runtime environment and
+  config; users configure `ros2-client` exactly as they configure ROS 2 nodes.
+- **Con:** an external router process is part of the normal runtime (a real
+  operational difference from the self-contained RustDDS backend). CI must run
+  `zenohd` for interop. Multicast-only (router-free) operation is possible via
+  override but not the default.

--- a/docs/zenoh_study/README.md
+++ b/docs/zenoh_study/README.md
@@ -1,0 +1,61 @@
+# Zenoh backend study for `ros2-client`
+
+This folder is the technical study behind adding **Zenoh** support to
+`ros2-client` (issue [#71](https://github.com/Atostek/ros2-client/issues/71)),
+alongside the existing RustDDS backend, as a mutually-exclusive cargo feature.
+
+## Executive summary
+
+`ros2-client` is a generic, serde-based ROS 2 client on top of RustDDS. Adding a
+Zenoh backend is feasible **without broad renames** by using compile-time backend
+selection (`dds` default / `zenoh` opt-in) and introducing a small set of owned
+public types where RustDDS currently leaks through the API. The message wire
+format (CDR) and the ROS naming convention are shared and port directly; the
+RTPS-specific machinery (GUID identity, `SampleIdentity` RPC correlation, DDS
+discovery, DDS QoS) is rebuilt over Zenoh following the official `rmw_zenoh`
+design:
+
+- **Transport model:** one `zenoh::Session` per `Context` (peer mode; a `zenohd`
+  router is required by default for discovery).
+- **Topics → key expressions:** `<domain>/<name>/<type>/<type_hash>`.
+- **Discovery → liveliness tokens** under `@ros2_lv/<domain>/**` + a graph cache.
+- **Messages carry an attachment** `(seq, source_timestamp, source_gid)`.
+- **Services → Zenoh queryable/get**; correlation via the attachment, not RTPS.
+- **GID → XXH3-128** of the entity's liveliness key.
+- **Actions → services + topics** (no special Zenoh handling).
+
+The single biggest **interop risk** is the REP-2016 **type hash** in key
+expressions: `ros2-client` doesn't compute one today. The MVP resolves this with
+liberal wildcard-receive plus a known-types hash table, deferring full IDL-based
+hashing (see ADR-0007).
+
+## How to read this study
+
+| Document | Purpose |
+|----------|---------|
+| [`feature_map.md`](feature_map.md) | The core: every `ros2-client` feature mapped to its ROS 2 concept, the `rmw_zenoh` Zenoh realisation, the mismatch, and the refactor it implies. |
+| [`refactoring_plan.md`](refactoring_plan.md) | The abstraction design (compile-time backend selection), the dependency graph, and the ordered work items **E0–E10** that become GitHub issues. |
+| [`test_plan.md`](test_plan.md) | Lean 3-tier test strategy (unit wire-format / in-process integration / real-ROS-2 interop) and the CI design under a < 30 min budget. |
+| [`research/`](research/) | Raw ground-truth references gathered up front (appendices). |
+
+### Research appendices
+- [`research/rmw_zenoh.md`](research/rmw_zenoh.md) — the official ROS 2 ↔ Zenoh
+  middleware: exact key-expression/liveliness/attachment/service/QoS/GID formats.
+- [`research/zenoh_api.md`](research/zenoh_api.md) — the Zenoh 1.x Rust API
+  (session/pub/sub/queryable/get/liveliness/attachments/`zenoh-ext`).
+- [`research/ros2_client_internals.md`](research/ros2_client_internals.md) — a
+  feature-by-feature map of the current crate and every RustDDS coupling point.
+- [`research/workshop_use_cases.md`](research/workshop_use_cases.md) — the RosCon
+  2025 workshop use cases → testable scenarios.
+
+## Decision records
+
+Design decisions and compromises are recorded as ADRs under
+[`../decisions/`](../decisions/). Start at
+[`0001-record-architecture-decisions.md`](../decisions/0001-record-architecture-decisions.md).
+
+## Status
+
+Study, plan, test plan, and decision records: **complete**. Implementation is
+tracked by the E0–E10 GitHub issues generated from
+[`refactoring_plan.md`](refactoring_plan.md).

--- a/docs/zenoh_study/feature_map.md
+++ b/docs/zenoh_study/feature_map.md
@@ -1,0 +1,227 @@
+# Feature map: `ros2-client` ↔ ROS 2 ↔ Zenoh
+
+This is the technical heart of the study. For every feature of `ros2-client`
+it records: the current DDS-based implementation, the corresponding ROS 2
+concept, the `rmw_zenoh` (ground-truth) realisation over Zenoh, the **mismatch**
+that a Zenoh backend must resolve, and the **refactor** it implies.
+
+Sources: [`research/ros2_client_internals.md`](research/ros2_client_internals.md),
+[`research/rmw_zenoh.md`](research/rmw_zenoh.md),
+[`research/zenoh_api.md`](research/zenoh_api.md).
+
+Legend for effort/risk: 🟢 mechanical · 🟡 moderate · 🔴 hard / interop-critical.
+
+---
+
+## 0. The shape of the problem
+
+`ros2-client` is a thin, generic layer: the user brings a serde-serialisable
+Rust type `M`, and the crate handles CDR encoding, DDS entity creation, naming,
+discovery, services, actions, parameters, and logging. RustDDS types leak into
+the public API in a handful of well-defined places (QoS, `Timestamp`, `GUID`/
+`Gid`, `RmwRequestId`, `MessageInfo`, `NodeEvent`, error types). The data wire
+format (CDR) and the ROS naming convention are **shared** between DDS and Zenoh
+— those port directly. What does *not* port is everything RTPS-specific:
+GUID-based identity, `SampleIdentity`/inline-QoS RPC correlation, DDS discovery
+(both SEDP matching and the `ros_discovery_info` topic), and the DDS QoS model.
+
+`rmw_zenoh` shows the target: one Zenoh **session** per context; topics are
+Zenoh **key expressions** `<domain>/<name>/<type>/<hash>`; discovery is
+**liveliness tokens** under `@ros2_lv/**`; every message carries an
+**attachment** `(seq, timestamp, gid)`; services are **queryable + get**; GIDs
+are XXH3-128 hashes of the liveliness key. CDR payloads are byte-identical.
+
+---
+
+## 1. Serialization (CDR) — 🟢 reuse
+
+| | |
+|---|---|
+| **ros2-client today** | RustDDS `no_key::DataWriterCdr`/`SimpleDataReaderCdr` + serde; `RepresentationIdentifier::CDR_LE`; a 4-byte CDR encapsulation header prepended by RustDDS. |
+| **ROS 2** | OMG CDR (XCDR1) with 4-byte encapsulation header (`00 01 00 00` = CDR_LE). |
+| **rmw_zenoh** | Identical CDR bytes (incl. the 4-byte encapsulation header) are the Zenoh payload. |
+| **Mismatch** | The CDR machinery is currently reached *through* RustDDS writer/reader adapters. A Zenoh backend has no writer/reader. |
+| **Refactor** | Serialise `M` to `Vec<u8>` with the standalone [`cdr-encoding`](https://lib.rs/crates/cdr-encoding) crate (`to_vec::<M, LittleEndian>()` / `from_bytes`), prepend the 4-byte encapsulation header, and hand the bytes to `session.put(...)`. `cdr-encoding` is already a transitive dependency and is authored by the RustDDS author, so byte-for-byte parity is expected. Encapsulation-header handling becomes a tiny shared helper. |
+
+> **Important detail:** confirm whether `cdr-encoding::to_vec` emits the 4-byte
+> encapsulation header or only the body. RustDDS adds it separately
+> (`to_writer_with_rep_id`). The Zenoh backend must ensure the header is present
+> exactly once. This is verified in the first pub/sub implementation issue.
+
+---
+
+## 2. Naming — 🟢 reuse, adapt to key expressions
+
+| | |
+|---|---|
+| **ros2-client today** | `src/names.rs`: `to_dds_name("rt"/"rq"/"rr", node, suffix)` → `rt/ns/topic`; `dds_msg_type()` → `pkg::msg::dds_::Type_`; `_Request_`/`_Response_`/`_Reply` suffixes. Pure string ops. |
+| **ROS 2** | [Topic and Service name mapping to DDS](https://design.ros2.org/articles/topic_and_service_names.html). |
+| **rmw_zenoh** | Data key: `<domain>/<fqn_no_slashes>/<type_name>/<type_hash>` (real slashes kept). Liveliness key: name **mangled** `/`→`%`, empty→`%`. Service uses same scheme with `srv` type. |
+| **Mismatch** | (a) Zenoh keys prepend `<domain_id>` and append `<type_name>/<type_hash>` — the `rt/`/`rq/`/`rr/` prefix is **not** used in the data key (queryable vs subscriber distinguishes req/resp; the *name* is the bare `/add_two_ints`). (b) Liveliness keys use `%` mangling. (c) A **type hash** is required (see §11). |
+| **Refactor** | Add Zenoh key-expression builders alongside `to_dds_name`. Keep `names.rs` string algorithms; add: `zenoh_topic_keyexpr(domain, name, type, hash)`, `zenoh_liveliness_keyexpr(...)` with `%` mangling, and the DDS type-name reuse (`dds_msg_type()` is exactly `<type_name>`). |
+
+---
+
+## 3. Context / Session — 🟡
+
+| | |
+|---|---|
+| **ros2-client today** | `Context` wraps one RustDDS `DomainParticipant` (+ default pub/sub, discovery/rosout/param topics). `Context::new()` / `with_options(domain_id, security)`. |
+| **ROS 2** | One context ↔ one middleware participant. |
+| **rmw_zenoh** | One context ↔ one `zenoh::Session` (peer mode), plus a graph-cache liveliness subscriber and an initial liveliness get. Config from JSON5 (`ZENOH_SESSION_CONFIG_URI`, `ZENOH_CONFIG_OVERRIDE`); **needs a `zenohd` router** by default. |
+| **Mismatch** | `DomainParticipant` ↔ `Session` are different lifecycles; Zenoh needs an async runtime and a live router; `ContextOptions` (domain_id, DDS security) differ from Zenoh options (config path/overrides, connect/listen endpoints, router-check attempts). |
+| **Refactor** | `ContextInner` becomes backend-specific: `#[cfg(feature="dds")]` keeps the participant; `#[cfg(feature="zenoh")]` owns a `Session` + graph cache. `ContextOptions` gains a zenoh-only `zenoh_config`/overrides path; `domain_id` stays (Zenoh uses it as key prefix, not transport). See [refactoring_plan.md](refactoring_plan.md). |
+
+---
+
+## 4. Publish / Subscribe — 🟡
+
+| | |
+|---|---|
+| **ros2-client today** | `Publisher<M>` wraps `DataWriterCdr<M>`; `Subscription<M>` wraps `SimpleDataReaderCdr<M>`; async stream via RustDDS; `MessageInfo` from `SampleInfo`. QoS = `QosPolicies`. |
+| **ROS 2** | Publisher/Subscription with QoS. |
+| **rmw_zenoh** | Volatile: `declare_publisher`/`declare_subscriber` + `put` with attachment `(seq, ts, gid)`. `TRANSIENT_LOCAL`: `zenoh-ext` `AdvancedPublisher` (publication cache) + `AdvancedSubscriber` (history query). `KEEP_ALL`+`RELIABLE` → congestion-control `BLOCK`. |
+| **Mismatch** | No DataWriter/Reader; async by construction (Zenoh subscriber callback/stream on Zenoh runtime threads); `MessageInfo` fields (seq, source ts, publisher gid) come from the **attachment** not `SampleInfo`; `depth==0`→42; transient-local needs `zenoh-ext` + session timestamping. |
+| **Refactor** | Backend-specific `Publisher`/`Subscription` internals; a shared `MessageInfo` populated from attachments in the Zenoh path. Publisher assigns a per-publisher monotonic sequence number. Map QoS profile → (volatile vs advanced, congestion control). |
+
+---
+
+## 5. QoS — 🔴 public-API decoupling
+
+| | |
+|---|---|
+| **ros2-client today** | `rustdds::QosPolicies` / `QosPolicyBuilder` / `policy::*` in the public API of `create_topic/publisher/subscription/client/server`, action QoS structs, and re-exported via `ros2::`. |
+| **ROS 2** | `rmw_qos_profile_t`: reliability, durability, history, depth, deadline, lifespan, liveliness, lease. |
+| **rmw_zenoh** | QoS behaviourally emulated (reliability→transport, transient_local→cache, keep_all→BLOCK, deadline/lifespan carried-not-enforced, liveliness AUTOMATIC only) **and** delta-encoded into the liveliness keyexpr `<qos>` field against a canonical default. |
+| **Mismatch** | The DDS QoS type has knobs Zenoh ignores (`max_blocking_time`, `Ownership`) and a different default matrix. Cannot pull `rustdds` under the `zenoh` feature just for the type. |
+| **Refactor** | Introduce an **owned** `ros2_client::qos::QosProfile` (the ROS 2 profile: reliability/durability/history/depth/deadline/lifespan/liveliness/lease). Under `dds`, `From`/`Into` `rustdds::QosPolicies`. Under `zenoh`, drive publisher/subscriber options + the `<qos>` keyexpr encoding. Keep `ros2::QosPolicies` as a compat alias where feasible to minimise churn (see ADR-0004). This is the single largest public-API change. |
+
+---
+
+## 6. Discovery / ROS graph — 🔴 mechanism swap
+
+| | |
+|---|---|
+| **ros2-client today** | Dual: (a) RTPS `DomainParticipantStatusEvent` stream → match maps → `wait_for_reader/writer`, pub/sub counts; (b) `ros_discovery_info` data topic carrying `rmw_dds_common::ParticipantEntitiesInfo` (`Gid` lists) → ROS node/topic graph. `NodeEvent::{DDS,ROS}`. |
+| **ROS 2** | Node/topic/service/action graph introspection. |
+| **rmw_zenoh** | **Liveliness tokens**: every entity declares a token whose key encodes all metadata (`@ros2_lv/<domain>/<zid>/<nid>/<eid>/<kind>/<enclave>/<ns>/<node>/<name>/<type>/<hash>/<qos>`). A liveliness subscriber on `@ros2_lv/<domain>/**` + an initial `liveliness_get` build/maintain a graph cache. |
+| **Mismatch** | Entirely different mechanism. No `ros_discovery_info` topic, no SEDP. Entity counts / `wait_for_*` must be derived from the graph cache (matching by name/type/hash), not GUID matching. `NodeEvent::DDS(...)` leaks a RustDDS type. |
+| **Refactor** | Zenoh backend maintains a graph cache from liveliness tokens. `wait_for_reader/writer` and `get_*_count` reimplemented over the cache. Introduce a backend-neutral `NodeEvent`/graph-event type (deprecate `NodeEvent::DDS`). Liveliness key build/parse (+ QoS + mangling + type hash) is a large new module. |
+
+---
+
+## 7. Services — 🔴 correlation redesign
+
+| | |
+|---|---|
+| **ros2-client today** | Request topic `rq/.../Request` + reply topic `rr/.../Reply`. Three `ServiceMapping`s (Basic/Enhanced/Cyclone). Correlation = `RmwRequestId {GUID, SequenceNumber}` (== `rpc::SampleIdentity`). Enhanced uses RTPS **inline-QoS `related_sample_identity`**. |
+| **ROS 2** | Service client/server, request/response correlated by a request id. |
+| **rmw_zenoh** | Server = `declare_queryable(key).complete(true)`; client = `declare_querier(key)`/`get` with `target=ALL_COMPLETE`, `consolidation=None`. Request/response carry attachment `(seq, ts, client_gid)`; server keys pending queries by `hash(client_gid)→seq`, echoes seq+gid in the reply; client correlates by the echoed seq. Long timeout for `**/_action/get_result/**`. |
+| **Mismatch** | No request/reply *topics*; it's query/reply. No `SampleIdentity`/inline-QoS. `RmwRequestId` semantics change: `writer_guid` becomes the client entity GID (XXH3), `sequence_number` a client-local counter. The three DDS `ServiceMapping`s are irrelevant over Zenoh — Zenoh has exactly one mapping (query/reply + attachment). |
+| **Refactor** | A Zenoh service path: `Server` owns a queryable + a pending-query map; `Client` owns a querier + reply channels. Keep the public `Client`/`Server` API and `RmwRequestId` shape (opaque 16-byte id + seq) but change provenance. Under `zenoh`, `ServiceMapping` is ignored (document as a no-op / hidden). This is the most involved single feature. |
+
+---
+
+## 8. Actions — 🟡 (free once services+pubsub work)
+
+| | |
+|---|---|
+| **ros2-client today** | Composed from 3 services (send_goal, cancel_goal, get_result) + 2 topics (feedback, status). `GoalId` (UUID) correlation is application-level. |
+| **rmw_zenoh** | No action concept — pure services+topics. Only quirk: `get_result` querier gets an ~infinite timeout. |
+| **Mismatch** | None structural; inherits service/pubsub porting. |
+| **Refactor** | Almost none beyond services+pubsub. Add the `get_result` long-timeout heuristic (key intersects `**/_action/get_result/**`). `GoalId` correlation ports unchanged. |
+
+---
+
+## 9. Parameters — 🟢 (once services work)
+
+| | |
+|---|---|
+| **ros2-client today** | Six `Server<rcl_interfaces::*>` (Enhanced mapping) + `rt/parameter_events` publisher. Enum↔raw conversion is DDS-agnostic. `ParameterEvent.timestamp` is a `rustdds::Timestamp`. |
+| **rmw_zenoh** | Ordinary services + a topic. |
+| **Mismatch** | Only the `Timestamp` field type and the fact it rides on services. |
+| **Refactor** | Replace `rustdds::Timestamp` with an owned timestamp (§10). Otherwise inherits services+pubsub. |
+
+---
+
+## 10. Time — 🟢/🟡
+
+| | |
+|---|---|
+| **ros2-client today** | `ROSTime`/`SystemTime`/`steady_time`; conversions to/from `rustdds::Timestamp` (RTPS `Time_t`); `Timestamp` re-exported as `ros2::Timestamp` and used in message structs (`Log`, `ParameterEvent`) and `MessageInfo`. |
+| **rmw_zenoh** | Source timestamp is `int64` ns since epoch in the attachment. |
+| **Mismatch** | `rustdds::Timestamp` is RTPS-specific and re-exported publicly. |
+| **Refactor** | Introduce an owned time/timestamp type (or reuse `builtin_interfaces::Time` / `ROSTime`) for message fields and `MessageInfo`. Under `dds`, convert to/from `rustdds::Timestamp`. Under `zenoh`, ns-epoch i64 in attachments. |
+
+---
+
+## 11. Type hash (REP-2016 `RIHS01_...`) — 🔴 interop-critical, new capability
+
+| | |
+|---|---|
+| **ros2-client today** | **Absent.** The crate never computes a type hash — it's a generic serde client. |
+| **ROS 2 / rmw_zenoh** | Keys and liveliness tokens include a REP-2016 RIHS01 type hash (SHA-256 over a canonical JSON type description). Two entities only match if name **and** type **and** hash agree. |
+| **Mismatch** | Without the correct hash, a `ros2-client` **publisher's** concrete key will not match a C++ `rmw_zenoh` **subscriber's** concrete key → no interop in the send direction. `ros2-client`↔`ros2-client` works with any agreed placeholder. |
+| **Strategy (see ADR-0007)** | Layered: **(a)** subscribers/queryables declare with a `**` wildcard on the hash slot → receive from any hash (fixes the *receive* direction immediately). **(b)** For the *send* direction to C++ peers, provide correct hashes via a small **known-types table** for the common interop types (std_msgs, example_interfaces AddTwoInts/Fibonacci, geometry_msgs Twist, etc.), and let users supply a hash explicitly. **(c)** Longer term, compute RIHS01 from parsed `.msg`/`.srv` IDL in `msggen`. MVP ships (a)+(b). |
+
+---
+
+## 12. GID / entity identity — 🔴
+
+| | |
+|---|---|
+| **ros2-client today** | `Gid` = padded RustDDS `GUID` (16/24 B, distro-gated); implements RustDDS `Key`/`CdrEncodingSize`; used in `ParticipantEntitiesInfo`, `MessageInfo`, service correlation. |
+| **rmw_zenoh** | GID = XXH3-128 of the entity's liveliness keyexpr (low64‖high64, LE); 16 bytes. |
+| **Mismatch** | Provenance changes from GUID to a hash; correlation and attachments must use it. `Gid` should stay a 16-byte opaque id but be generated differently under `zenoh`. |
+| **Refactor** | Keep the `Gid` type (drop `Key`/`CdrEncodingSize` reliance under `zenoh`); add `zenoh` construction via a stable XXH3-128 (crate [`xxhash-rust`](https://crates.io/crates/xxhash-rust) `xxh3`) over the liveliness key. Verify byte order vs `rmw_zenoh` (ADR-0008). |
+
+---
+
+## 13. Error types — 🟡 public-API decoupling
+
+| | |
+|---|---|
+| **ros2-client today** | `CreateError`/`ReadError`/`WriteError`/`WaitError` from `rustdds::dds`, re-exported via `ros2::`; `NodeCreateError::DDS(...)`, `GoalError::DDS*`, `CallServiceError`. |
+| **Mismatch** | Cannot re-export `rustdds` errors under the `zenoh` feature. |
+| **Refactor** | Define owned error enums (`ros2_client::Error`, per-operation variants) with `#[cfg]` inner variants wrapping the backend error (`rustdds::dds::*` vs `zenoh::Error`). Keep `ros2::` names as aliases where possible (ADR-0004). |
+
+---
+
+## 14. `mio::Evented` sync polling — 🟡 drop under zenoh
+
+| | |
+|---|---|
+| **ros2-client today** | `Subscription`/`Client`/`Server` implement `mio::Evented` by delegating to RustDDS. |
+| **Mismatch** | Zenoh has no mio integration; it's async-first. |
+| **Refactor** | Under `zenoh`, do **not** implement `mio::Evented`; provide async streams only (the README already recommends async). Document sync/mio polling as a `dds`-only capability. |
+
+---
+
+## 15. Security — 🟡 divergent
+
+| | |
+|---|---|
+| **ros2-client today** | Optional DDS Security (`security` feature → RustDDS security). |
+| **rmw_zenoh** | Security via Zenoh (mTLS/QUIC, access control) configured in the session/router JSON5, not SROS artifacts. |
+| **Mismatch** | Completely different models. |
+| **Refactor** | Out of scope for MVP. Keep `security` as a `dds`-only feature; document Zenoh transport security as configuration-driven (future work). |
+
+---
+
+## Summary: what ports vs what is rebuilt
+
+**Ports directly (shared):** CDR (via `cdr-encoding`), `names.rs` string algorithms
+and type-name mangling, the message/IDL struct definitions, parameter enum↔raw
+layer, action `GoalId` correlation, `ROSTime`/duration arithmetic.
+
+**Owned types to introduce (decouple public API):** `QosProfile`, timestamp,
+error enums, backend-neutral `NodeEvent`/graph events. `Gid` stays but changes
+provenance; `RmwRequestId` stays but changes provenance.
+
+**Rebuilt for Zenoh:** session/context, pub/sub over `put`/`declare_subscriber`
+(+ `zenoh-ext` for transient-local), liveliness-token discovery + graph cache,
+services over queryable/get, GID via XXH3-128, QoS keyexpr encoding, and a new
+type-hash capability.
+
+**Dropped under `zenoh`:** `mio::Evented`, DDS `ServiceMapping` variants, DDS
+security, `ros_discovery_info` topic, `DomainParticipantStatusEvent`.

--- a/docs/zenoh_study/interop_runbook.md
+++ b/docs/zenoh_study/interop_runbook.md
@@ -1,0 +1,149 @@
+# Tier-C interop runbook (ros2-client `zenoh` ↔ real ROS 2 + `rmw_zenoh`)
+
+The in-tree tests cover Tier A (byte-exact wire-format unit tests) and Tier B
+(two `ros2-client` peers in-process over loopback, plus the client→router→client
+path in `pub_sub_through_router`). **Tier C** — validating against a *real* ROS 2
+stack using the official `rmw_zenoh` middleware — needs a ROS 2 installation and
+is therefore run manually rather than in this repo's CI (which has no ROS 2
+environment). This runbook is the concrete procedure; each step maps to a `C#`
+acceptance criterion from the epic (#2) work items.
+
+## 0. Prerequisites
+
+Install ROS 2 (Jazzy or newer) and the Zenoh RMW, then start a router. `rmw_zenoh`
+requires a running router (`zenohd`); `ros2-client`'s Zenoh backend does too for
+multi-process discovery (ADR-0009).
+
+```bash
+# ROS 2 + rmw_zenoh (Jazzy example)
+sudo apt install ros-jazzy-desktop ros-jazzy-rmw-zenoh-cpp
+source /opt/ros/jazzy/setup.bash
+export RMW_IMPLEMENTATION=rmw_zenoh_cpp
+
+# Terminal R: the router (from rmw_zenoh, or a standalone zenohd)
+ros2 run rmw_zenoh_cpp rmw_zenohd
+```
+
+Point `ros2-client` at the same router. With the default config it listens on
+loopback in peer mode; for interop set it to connect to the router:
+
+```bash
+export ZENOH_CONFIG_OVERRIDE='mode="client";connect/endpoints=["tcp/localhost:7447"]'
+```
+
+(`ZENOH_SESSION_CONFIG_URI` can instead point at the full `rmw_zenoh` JSON5
+session config. Both are honoured by `Context` — see
+`config_from_env` and ADR-0009.)
+
+Keep the ROS domain id aligned on both sides (`ROS_DOMAIN_ID`, and
+`ContextOptions::domain_id`; the Zenoh backend uses it as the key-expression
+prefix).
+
+## 1. Topics — C4
+
+`ros2-client` publishes, ROS 2 subscribes:
+
+```bash
+# Run the bundled example against the router (edit it to use ZENOH_CONFIG_OVERRIDE
+# or run your own talker built with `--no-default-features --features zenoh`).
+cargo run --no-default-features --features zenoh --example zenoh_demo
+# ROS 2 side:
+ros2 topic echo /chatter std_msgs/msg/String
+```
+
+ROS 2 publishes, `ros2-client` subscribes:
+
+```bash
+ros2 topic pub /chatter std_msgs/msg/String "{data: 'hello from ros2'}"
+# ros2-client subscription should receive "hello from ros2"
+```
+
+> Note on the **send** direction to C++ peers: for types outside the
+> known-types table, `ros2-client` currently emits a placeholder REP-2016 hash,
+> so a C++ subscriber that keys on the real hash may not match. Types in the
+> table (`std_msgs/String`, `example_interfaces/srv/AddTwoInts`, …) match. The
+> **receive** direction is universal (wildcard hash). See ADR-0007; the
+> `type_description` module now computes real hashes and the remaining `msggen`
+> integration closes this gap.
+
+## 2. Services — C6
+
+`ros2-client` server, ROS 2 client:
+
+```bash
+# ros2-client: create_server on /add_two_ints (example_interfaces/AddTwoInts)
+ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts "{a: 2, b: 40}"
+# expect: sum=42
+```
+
+ROS 2 server, `ros2-client` client:
+
+```bash
+ros2 run examples_rclpy_minimal_service service
+# ros2-client: create_client on /add_two_ints, call {a,b}, expect a+b
+```
+
+## 3. Actions — C7
+
+```bash
+# ROS 2 server:
+ros2 run action_tutorials_cpp fibonacci_action_server
+# ros2-client: create_action_client on /fibonacci
+#   (action_tutorials_interfaces/Fibonacci), send_goal {order: 5},
+#   observe feedback + /status, fetch result [0,1,1,2,3].
+# Also exercise cancel:
+#   send a long goal, cancel_goal(goal_id), observe Canceled on /status.
+```
+
+And the reverse (ros2-client server, `ros2 action send_goal` client):
+
+```bash
+ros2 action send_goal /fibonacci action_tutorials_interfaces/action/Fibonacci "{order: 5}" --feedback
+```
+
+## 4. Parameters — C8
+
+```bash
+# ros2-client: node with create_parameter_server([("speed", 1.0), ...]), spinning.
+ros2 param list /param_holder
+ros2 param get  /param_holder speed
+ros2 param set  /param_holder speed 2.5
+ros2 param describe /param_holder speed
+```
+
+Each should round-trip against the six `rcl_interfaces` services, and
+`ros2 param set` should emit a `/parameter_events` message.
+
+## 5. rosout — C9
+
+```bash
+# ros2-client: create_logger(); rosout!(logger, LogLevel::Info, "…")
+ros2 topic echo /rosout rcl_interfaces/msg/Log
+# expect the log line, with matching level/name/msg/file/line.
+```
+
+## 6. Discovery / ROS graph — C5
+
+```bash
+ros2 node list        # should list the ros2-client node(s)
+ros2 topic list       # should list their topics
+ros2 topic info /chatter --verbose   # publisher/subscriber counts
+```
+
+On the `ros2-client` side, `Context::node_names()` / `publisher_count()` /
+`graph_event_stream()` should reflect the ROS 2 entities.
+
+## Recording results
+
+Capture pass/fail per criterion in `interop/results/` (mirroring the DDS
+backend's interop results layout) with the ROS distro, `rmw_zenoh` version, and
+`zenohd` version noted — the type-hash values in particular are distro-sensitive
+(see ADR-0007 on `ServiceEventInfo`).
+
+## Automating this later
+
+A `workflow_dispatch` CI job could run this against a `ros-jazzy` container with
+`rmw_zenoh_cpp` installed and `rmw_zenohd` started as a service step. It is
+intentionally **not** added to the always-on CI here because it needs a ROS 2
+image and a router daemon; wire it up in an environment that has both, using the
+commands above as the script.

--- a/docs/zenoh_study/issues.md
+++ b/docs/zenoh_study/issues.md
@@ -1,0 +1,108 @@
+# Planned GitHub issues (ready to create)
+
+> These were meant to be created directly on `semio-ai/ros2-client`, but the
+> session's GitHub access is currently **read-only** (issue creation and content
+> writes both return `403 Resource not accessible by integration`, and
+> `git push` returns `403` via the git proxy). They are captured here so they can
+> be created verbatim once write access is granted (see the note at the bottom).
+>
+> Full detail for each item is in [`refactoring_plan.md`](refactoring_plan.md);
+> acceptance/tests in [`test_plan.md`](test_plan.md).
+
+Suggested labels: `zenoh`, `enhancement`. Suggested milestone: `Zenoh MVP`.
+
+---
+
+## Epic: Zenoh backend for ros2-client (issue #71)
+
+Body: link the study (`docs/zenoh_study/`) and decisions (`docs/decisions/`),
+the approach (ADR-0002), and the dependency graph below with checkboxes for
+E0–E10. Reference upstream `Atostek/ros2-client#71`.
+
+```
+E0 scaffolding ──┬── E1 owned types ──┐
+                 ├── E2 wire prims ────┼── E4 pub/sub ──┐
+                 └── E3 session ───────┤                ├── E6 services ──┬── E7 actions
+                                       └── E5 discovery ─┘                 ├── E8 params
+                                              (E4 also feeds E9 rosout)    └── E9 rosout
+```
+
+## E0 — Feature scaffolding: `dds` (default) / `zenoh` (opt-in, exclusive)
+- Depends on: —
+- Add `dds`/`zenoh` features; `default=["dds"]`; `compile_error!` if both/neither;
+  gate all `rustdds` deps/uses behind `dds`; add `zenoh`/`zenoh-ext` optional deps;
+  both configs build (`cargo check --no-default-features --features {dds,zenoh}`);
+  CI matrix builds both. Zenoh path may be `todo!()` stubs behind a clear boundary.
+
+## E1 — Owned public types (decouple from RustDDS)
+- Depends on: E0
+- `qos::QosProfile`, owned timestamp, `error` enums, backend-neutral `NodeEvent`;
+  `dds` `From/Into` RustDDS; keep `ros2::` aliases; DDS tests unchanged. (ADR-0004)
+
+## E2 — Zenoh wire primitives: keyexpr / attachment / type-hash / gid / CDR
+- Depends on: E0
+- Data + liveliness key builders (`%` mangling, `<qos>` delta encoding);
+  attachment `(i64 seq,i64 ts,[u8;16] gid)` via `zenoh_ext::z_serialize`;
+  type-hash known-table + wildcard-receive; XXH3-128 gid; CDR encapsulation helper.
+  Unit tests pin exact strings/bytes from `research/rmw_zenoh.md`. (ADR-0003/7/8)
+
+## E3 — Zenoh session / Context + config
+- Depends on: E0
+- `ContextInner` opens a `zenoh::Session` (peer defaults ≈
+  `DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5`); honour `ZENOH_SESSION_CONFIG_URI`/
+  `ZENOH_CONFIG_OVERRIDE`; retain `domain_id`; document router requirement. (ADR-0009)
+
+## E4 — Pub/Sub over Zenoh
+- Depends on: E1, E2, E3
+- `Publisher`/`Subscription` zenoh internals; volatile put+attachment / subscriber
+  stream; transient-local via `zenoh-ext` cache+history; `MessageInfo` from
+  attachment; congestion control for keep_all+reliable.
+- Interop (Tier C1–C3): `ros2 topic echo/pub/list` round-trips.
+
+## E5 — Discovery: liveliness tokens + graph cache
+- Depends on: E2, E3
+- Per-entity liveliness tokens; graph-cache subscriber on `@ros2_lv/<domain>/**` +
+  initial get; reimplement `wait_for_*` and `get_*_count` over the cache;
+  backend-neutral events. (ADR-0005)
+- Interop: `ros2 node list` shows the node; graph sees C++ talker.
+
+## E6 — Services over queryable / get
+- Depends on: E4, E5
+- Server queryable(`complete`) + pending map `hash(gid)→seq`; client querier/get
+  (`ALL_COMPLETE`, `consolidation=None`); attachment correlation; `RmwRequestId`
+  provenance change; `ServiceMapping` no-op under zenoh; `get_result` long timeout. (ADR-0006)
+- Interop (C4/C5): `add_two_ints` both directions.
+
+## E7 — Actions over Zenoh
+- Depends on: E6
+- Verify actions via services+topics; add `**/_action/get_result/**` long timeout.
+- Interop (C6/C7): `Fibonacci` both directions.
+
+## E8 — Parameters over Zenoh
+- Depends on: E6
+- Param services + `parameter_events` topic with owned timestamp.
+- Interop (C8): `ros2 param set/get`.
+
+## E9 — rosout logging over Zenoh
+- Depends on: E4
+- `rt/rosout` key publisher with owned timestamp; optional inbound sub.
+- Interop (C9): `ros2 topic echo /rosout`.
+
+## E10 — Docs / examples / README / interop matrix
+- Depends on: E4–E9 (incremental)
+- README Zenoh section, router requirement, interop matrix; examples build under
+  `zenoh`; finalise ADRs; migration notes.
+
+## (Follow-up, post-MVP) — Compute RIHS01 type hashes from IDL in `msggen`
+- Depends on: E2
+- Full REP-2016 type-hash computation for arbitrary types (see ADR-0007c),
+  removing the known-types-table limitation for the send direction.
+
+---
+
+### How to create these once write access is granted
+The GitHub App installation for this session lacks `issues: write` /
+`contents: write` / `pull_requests: write` on `semio-ai/ros2-client`. An admin can
+grant it at <https://claude.ai/admin-settings> (Claude GitHub settings) or by
+adjusting the GitHub App's repository permissions. Then these issues can be created
+from this file (or directly from `refactoring_plan.md`).

--- a/docs/zenoh_study/refactoring_plan.md
+++ b/docs/zenoh_study/refactoring_plan.md
@@ -1,0 +1,262 @@
+# Refactoring & implementation plan
+
+Derived from [`feature_map.md`](feature_map.md). Goal: add a Zenoh backend to
+`ros2-client` behind a `zenoh` cargo feature, **mutually exclusive** with the
+default `dds` feature, with **minimal** disruption to the existing DDS code and
+public API (per issue [#71](https://github.com/Atostek/ros2-client/issues/71)
+and the user's explicit "keep it minimal" constraint).
+
+## Guiding principles
+
+1. **Minimal churn.** Prefer additive changes and `#[cfg(feature=...)]` seams
+   over sweeping renames. Where a public type must stop being a RustDDS type,
+   introduce an owned type and keep the old `ros2::` name as an alias/re-export
+   so downstream code keeps compiling under `dds`.
+2. **Interop with `rmw_zenoh` is the definition of done** for each feature —
+   verified against real ROS 2 (see [`test_plan.md`](test_plan.md)), not just
+   `ros2-client`↔`ros2-client`.
+3. **CDR and naming are shared**; do not fork them.
+4. **Async-first for Zenoh.** `mio`/sync polling stays a `dds`-only capability.
+5. **One session per context**, mirroring `rmw_zenoh`.
+
+## Two candidate architectures, and the choice
+
+**A. Trait-object backend abstraction** — define `trait Middleware` with
+associated `Publisher`/`Subscription`/`Client`/... and make `Context`/`Node`
+generic. *Rejected for MVP:* it forces generics through the entire public API
+(huge churn), fighting the "minimal" constraint, and the two backends are never
+used together (mutually exclusive features), so runtime polymorphism buys
+nothing.
+
+**B. Compile-time backend selection (`#[cfg(feature)]`)** — one public API;
+backend-specific *internals* selected by feature; a small set of owned public
+types (QoS, timestamp, errors, events, Gid provenance) shared by both. **Chosen**
+(ADR-0002). It matches the mutually-exclusive-feature model, keeps the DDS path
+byte-for-byte unchanged, and confines Zenoh code to new modules + `#[cfg]`
+branches in `context.rs`/`node.rs`/`pubsub.rs`/`service`.
+
+Concretely, the internals become:
+
+```
+Context ── #[cfg(dds)]  ─→ ContextInner { DomainParticipant, … }   (unchanged)
+        └─ #[cfg(zenoh)]─→ ContextInner { zenoh::Session, GraphCache, … }
+
+Publisher<M>    ── #[cfg(dds)] DataWriterCdr<M>
+                └─ #[cfg(zenoh)] { session, key_expr, seq, gid }
+
+Subscription<M> ── #[cfg(dds)] SimpleDataReaderCdr<M>
+                └─ #[cfg(zenoh)] { subscriber stream, PhantomData<M> }
+
+Client/Server   ── #[cfg(dds)] DataWriter/Reader + wrappers
+                └─ #[cfg(zenoh)] querier / queryable + pending map
+```
+
+Shared owned modules (compile in both, behaviour differs by cfg):
+`qos`, `time`, `error`, `graph` (NodeEvent), `gid`, plus new zenoh-only modules
+`zenoh_backend/{session,keyexpr,liveliness,attachment,type_hash,graph_cache}`.
+
+---
+
+## Dependency graph
+
+```
+          ┌─────────────────────────────────────────────┐
+          │ E0  Feature scaffolding (dds default,        │
+          │     zenoh opt-in, mutually exclusive, CI)    │
+          └───────────────┬─────────────────────────────┘
+                          │
+     ┌────────────────────┼───────────────────────────────┐
+     ▼                    ▼                                 ▼
+┌─────────┐        ┌────────────┐                    ┌────────────┐
+│ E1 Owned│        │ E2 CDR +   │                    │ E3 Zenoh   │
+│  public │        │  keyexpr   │                    │  session/  │
+│  types  │        │  + attach  │                    │  context + │
+│ (qos,   │        │  + type-   │                    │  config    │
+│  time,  │        │  hash +    │                    │            │
+│  error, │        │  gid(xxh3) │                    │            │
+│  events)│        └─────┬──────┘                    └─────┬──────┘
+└────┬────┘              │                                 │
+     │        ┌──────────┴───────────┐                     │
+     └────────┤                      │                     │
+              ▼                      ▼                     ▼
+        ┌───────────┐        ┌───────────────┐      (E3 also feeds
+        │ E4 Pub/Sub│        │ E5 Discovery  │       E4/E5/E6)
+        │ over Zenoh│◀───────│  liveliness + │
+        │ (+xtl)    │  graph │  graph cache  │
+        └─────┬─────┘  cache │  (wait_for_*, │
+              │              │   counts)     │
+              │              └───────┬───────┘
+              ▼                      │
+        ┌───────────┐               │
+        │ E6 Services│◀─────────────┘  (SC/SS liveliness)
+        │ queryable/ │
+        │ get        │
+        └─────┬──────┘
+              ├───────────────┬──────────────────┐
+              ▼               ▼                  ▼
+        ┌──────────┐   ┌────────────┐     ┌────────────┐
+        │ E7 Actions│  │ E8 Params  │     │ E9 rosout  │
+        └──────────┘   └────────────┘     └────────────┘
+
+  Cross-cutting, runs alongside: T* test/CI tasks (see test_plan.md),
+  D* decision records (docs/decisions).
+```
+
+Edges = "blocked by". E1/E2/E3 depend only on E0 and can proceed in parallel.
+E4 needs E1+E2+E3. E5 needs E2 (keyexpr/liveliness/gid)+E3. E6 needs E4-ish
+infra + E5 (client/server liveliness tokens). E7/E8/E9 need E6 (and E4).
+
+---
+
+## Work items (become GitHub issues)
+
+Each item lists: scope, key files, interop acceptance (the `rmw_zenoh` smoke
+test that defines done), and blocked-by.
+
+### E0 — Feature scaffolding: `dds` (default) / `zenoh` (opt-in, exclusive)
+- **Scope:** add `dds` and `zenoh` features; `default=["dds"]`; a
+  `compile_error!` if both or neither is enabled; gate all `rustdds` deps/uses
+  behind `dds`; add `zenoh`/`zenoh-ext` as `zenoh`-only optional deps; ensure
+  `cargo build`/`clippy`/`doc` pass in **both** configurations; add a CI matrix
+  entry building/checking the `zenoh` feature (no interop yet).
+- **Files:** `Cargo.toml`, `src/lib.rs`, `.github/workflows/*`.
+- **Done when:** `cargo check --no-default-features --features dds` and
+  `--features zenoh` both compile (zenoh path may be stubs/`todo!()` behind a
+  clear "unimplemented" boundary that still builds).
+- **Blocked by:** —
+
+### E1 — Owned public types (decouple from RustDDS)
+- **Scope:** introduce owned `qos::QosProfile`, `time` timestamp,
+  `error` enums, and a backend-neutral graph `NodeEvent`. Under `dds`, provide
+  `From`/`Into` to RustDDS equivalents and keep `ros2::` aliases so existing
+  examples/tests compile unchanged. Deprecate `NodeEvent::DDS` (keep under
+  `dds`). Provide `DEFAULT_PUBLISHER_QOS`/`DEFAULT_SUBSCRIPTION_QOS` as
+  `QosProfile`.
+- **Files:** new `src/qos.rs`, `src/time.rs` (or extend `ros_time`),
+  `src/error.rs`, `src/graph.rs`; touch `lib.rs`, `pubsub.rs`, `node.rs`,
+  `message_info.rs`, `builtin_topics.rs`.
+- **Done when:** DDS build + all existing tests pass using the owned types
+  (behaviourally identical); public API no longer *requires* naming a
+  `rustdds::` type for common pub/sub/service use.
+- **Blocked by:** E0.
+
+### E2 — Zenoh wire primitives: keyexpr, attachment, type hash, gid, CDR helper
+- **Scope (zenoh-only module, unit-testable without a network):**
+  - `keyexpr`: data key `<domain>/<name>/<type>/<hash>` + liveliness key builder/
+    parser with `%` mangling + compact `<qos>` encode/decode (delta-vs-default).
+  - `attachment`: `(i64 seq, i64 ts_ns, [u8;16] gid)` via `zenoh_ext::z_serialize`/
+    `z_deserialize`; round-trip + byte-layout test.
+  - `type_hash`: known-types table (RIHS01 for interop types) + `**` wildcard
+    strategy for receivers; explicit-hash override API.
+  - `gid`: XXH3-128 of the liveliness key (low64‖high64, LE).
+  - CDR encapsulation-header helper shared with E4.
+- **Files:** `src/zenoh_backend/{keyexpr,attachment,type_hash,gid}.rs`;
+  `Cargo.toml` (`xxhash-rust`).
+- **Done when:** unit tests reproduce the exact strings/bytes from
+  [`research/rmw_zenoh.md`](research/rmw_zenoh.md) §2–§7 (e.g. the `0/chatter/...`
+  key, the `::,7:,:,:,,` QoS string, the attachment byte layout, a known GID).
+- **Blocked by:** E0 (uses E1 `QosProfile` for QoS encoding — soft dep).
+
+### E3 — Zenoh session / Context + config
+- **Scope:** `ContextInner` (zenoh) opens a `zenoh::Session` from JSON5 config
+  (honour `ZENOH_SESSION_CONFIG_URI`, `ZENOH_CONFIG_OVERRIDE`, sensible peer
+  defaults matching `DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5`), holds the async
+  runtime, and exposes creation hooks. `ContextOptions` gains zenoh config knobs;
+  `domain_id` retained (key prefix). Document the `zenohd` router requirement.
+- **Files:** `src/context.rs` (`#[cfg]`), new `src/zenoh_backend/session.rs`,
+  bundled default config JSON5.
+- **Done when:** a context opens a session against a running `zenohd` in the test
+  env; graceful behaviour if no router (log + retry, like rmw_zenoh).
+- **Blocked by:** E0.
+
+### E4 — Pub/Sub over Zenoh
+- **Scope:** `Publisher<M>`/`Subscription<M>` zenoh internals; volatile via
+  `declare_publisher`+`put`(attachment) / `declare_subscriber` stream; transient-
+  local via `zenoh-ext` advanced pub/sub cache+history; `MessageInfo` from
+  attachment; per-publisher seq; congestion control for keep_all+reliable.
+  Publishers/subscribers declare their liveliness tokens (from E5) and the entity
+  gid.
+- **Files:** `src/pubsub.rs` (`#[cfg]`), `src/zenoh_backend/pubsub.rs`.
+- **Interop acceptance:** `ros2 topic echo /chatter` receives a `ros2-client`
+  `std_msgs/String` publish; a `ros2-client` subscription receives `ros2 topic
+  pub`; `ros2 topic list` shows the topic.
+- **Blocked by:** E1, E2, E3.
+
+### E5 — Discovery: liveliness tokens + graph cache
+- **Scope:** declare a liveliness token per entity (node/pub/sub/service/client);
+  a graph-cache liveliness subscriber on `@ros2_lv/<domain>/**` + initial
+  `liveliness().get()`; maintain a cache of remote entities; reimplement
+  `wait_for_reader/writer` and `get_publisher/subscription_count` over the cache
+  (match by name+type, hash liberal); backend-neutral `NodeEvent` emission.
+- **Files:** `src/node.rs` (`#[cfg]` spinner/graph), new
+  `src/zenoh_backend/{liveliness,graph_cache}.rs`.
+- **Interop acceptance:** `ros2 node list` shows a `ros2-client` node; `ros2-client`
+  sees a C++ talker's node/topic via its graph API; `wait_for_subscription`
+  resolves when `ros2 topic echo` starts.
+- **Blocked by:** E2, E3.
+
+### E6 — Services over queryable / get
+- **Scope:** `Server` = queryable(`complete=true`) + pending-query map keyed by
+  `hash(client_gid)→seq`, reply echoes seq+gid; `Client` = querier/`get`
+  (`ALL_COMPLETE`, `consolidation=None`) with per-client seq and reply channels;
+  `RmwRequestId` provenance change; `ServiceMapping` becomes a no-op under zenoh;
+  SC/SS liveliness tokens.
+- **Files:** `src/service/{client,server,mod}.rs` (`#[cfg]`), new
+  `src/zenoh_backend/service.rs`.
+- **Interop acceptance:** `ros2 service call /add_two_ints
+  example_interfaces/srv/AddTwoInts` answered by a `ros2-client` server; a
+  `ros2-client` client calls a C++ `add_two_ints` server and gets the sum;
+  `ros2 service list` shows it.
+- **Blocked by:** E4, E5.
+
+### E7 — Actions over Zenoh
+- **Scope:** verify actions work purely via E6 services + E4 topics; add the
+  `**/_action/get_result/**` long-timeout heuristic on the client querier.
+- **Interop acceptance:** `ros2 action send_goal /fibonacci
+  action_tutorials_interfaces/action/Fibonacci "{order: 5}" --feedback`
+  against a `ros2-client` action server (and the reverse).
+- **Blocked by:** E6.
+
+### E8 — Parameters over Zenoh
+- **Scope:** parameter services (E6) + `parameter_events` topic (E4) with owned
+  timestamp; verify against `ros2 param list/get/set`.
+- **Interop acceptance:** `ros2 param set/get` on a `ros2-client` node.
+- **Blocked by:** E6.
+
+### E9 — rosout logging over Zenoh
+- **Scope:** `rt/rosout`→Zenoh key publisher with owned timestamp; optional
+  inbound subscription.
+- **Interop acceptance:** `ros2 topic echo /rosout` shows a `ros2-client` log.
+- **Blocked by:** E4.
+
+### E10 — Documentation, examples, README, feature-status update
+- **Scope:** update README (Zenoh feature, router requirement, interop matrix),
+  make examples build under `zenoh`, finalise decision records, migration notes.
+- **Blocked by:** E4–E9 (incremental).
+
+---
+
+## Sequencing for delivery
+
+1. **E0** (unblocks everything; small, mergeable immediately).
+2. **E1**, **E2**, **E3** in parallel (independent).
+3. **E4** then **E5** (E5 can start on E2/E3; E4 consumes E5's liveliness/gid — in
+   practice land E5's token/gid plumbing first, then E4's data plane, then E5's
+   graph-cache consumers).
+4. **E6**, then **E7/E8/E9** in parallel.
+5. **E10** trails each feature.
+
+## Known risks / open questions (tracked in decision records)
+
+- **Type hash (E2/ADR-0007):** correct RIHS01 needed for send-direction interop
+  with C++ peers; MVP uses wildcard-receive + known-types table. Full IDL hashing
+  is future work.
+- **Attachment/GID byte parity (E2/ADR-0008):** `zenoh_ext::z_serialize` framing
+  and XXH3-128 byte order must match `rmw_zenoh` exactly; verified by unit tests +
+  live interop.
+- **Router requirement (E3/ADR-0009):** tests/CI must launch `zenohd` (or enable
+  multicast scouting) — impacts CI runtime and hermeticity.
+- **QoS default profile parity (E1/E2):** the delta-vs-default encoding only
+  interoperates if our canonical default equals `rmw_zenoh`'s.
+- **`cdr-encoding` encapsulation header:** verify header presence/duplication in
+  the first pub/sub round-trip.

--- a/docs/zenoh_study/research/rmw_zenoh.md
+++ b/docs/zenoh_study/research/rmw_zenoh.md
@@ -1,0 +1,572 @@
+# `rmw_zenoh` as ground truth for ROS 2 ↔ Zenoh mapping
+
+Research reference compiled from the official ROS 2 RMW implementation
+[`ros2/rmw_zenoh`](https://github.com/ros2/rmw_zenoh) (branch `rolling`,
+cloned 2026-07-07). This document is intended to drive a Rust `ros2-client`
+Zenoh backend, so it quotes exact format strings, field orderings, and the
+source locations they come from.
+
+Primary sources (all paths relative to the repo root):
+
+- `README.md`
+- `docs/design.md` — the authoritative design description.
+- `rmw_zenoh_cpp/src/detail/liveliness_utils.cpp` / `.hpp` — key expressions,
+  liveliness tokens, QoS encoding, GID generation, name mangling.
+- `rmw_zenoh_cpp/src/detail/attachment_helpers.cpp` — message/request attachments.
+- `rmw_zenoh_cpp/src/detail/rmw_client_data.cpp` — service client (querier / get).
+- `rmw_zenoh_cpp/src/detail/rmw_service_data.cpp` — service server (queryable / reply).
+- `rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5`
+- `rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5`
+
+A note on the interface version: `rmw_zenoh` today builds on **zenoh-cpp /
+zenoh-c ≈ Zenoh 1.x** and uses the **advanced pub/sub** and **querier** APIs
+(`declare_advanced_publisher`, `declare_advanced_subscriber`,
+`declare_querier`), plus `ext::Serializer`/`ext::Deserializer` for attachments.
+The Rust `zenoh` crate exposes the same concepts under `zenoh-ext`.
+
+---
+
+## 1. Overall architecture
+
+### Router requirement
+
+- A Zenoh **router (`zenohd`) is required in the default configuration.**
+  From `docs/design.md`: *"With the default configuration, `rmw_zenoh_cpp`
+  relies on a Zenoh router to discover peers and forward this discovery
+  information to other peers via Zenoh's `gossip scouting` functionality. Hence
+  `rmw_zenoh_cpp` requires the Zenoh router to be running."*
+- The router is **only used for discovery and host-to-host communication**, not
+  as a message broker. Actual data flows over **direct peer-to-peer**
+  connections between sessions (design.md "Brief overview": *"data is sent via
+  direct peer-to-peer connections"*).
+- `rmw_zenoh` ships its own router binary, launched with
+  `ros2 run rmw_zenoh_cpp rmw_zenohd` (source at `rmw_zenoh_cpp/src/zenohd/main.cpp`).
+- The router requirement is a *configuration choice*, not a protocol necessity:
+  if you enable UDP multicast scouting (disabled by default) peers can discover
+  each other without a router. The default disables multicast deliberately to
+  avoid cross-robot interference on a shared LAN and misconfigured-network
+  issues.
+
+### Mode: peer vs client vs router
+
+Default topologies (from `docs/design.md` table and the two config files):
+
+| Property        | Session (node)        | Router (`zenohd`)   |
+|-----------------|-----------------------|---------------------|
+| `mode`          | `peer`                | `router`            |
+| Listen          | `tcp/localhost:0`     | `tcp/[::]:7447`     |
+| Connect         | `tcp/localhost:7447`  | —                   |
+| Gossip scouting | enabled               | enabled             |
+| UDP multicast   | disabled              | disabled            |
+
+- Nodes run as **peers** that connect to the local router over loopback
+  (`tcp/localhost:7447`) and also listen on an OS-chosen loopback port
+  (`tcp/localhost:0`). Gossip scouting lets the router hand each peer the
+  endpoints of the others, so peers then form **p2p connections directly**.
+- A node can instead be configured as a **client** (e.g. remote RViz over a
+  network) via a custom session config.
+
+### Session model
+
+- **One ROS 2 context ↔ one Zenoh session** (`docs/design.md` "Contexts":
+  *"a context maps to a Zenoh session, along with a subscription to liveliness
+  tokens for the graph cache and some additional metadata"*). All publishers,
+  subscriptions, services, and clients in that context **share the one
+  session**.
+- The session is opened with `Session::open(config)`. Config comes from
+  `DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5` unless `ZENOH_SESSION_CONFIG_URI`
+  points elsewhere; per-field overrides via `ZENOH_CONFIG_OVERRIDE=
+  "key/path=value;..."`.
+- Relevant default session-config knobs (from
+  `DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5`):
+  - `mode: "peer"`, `connect.endpoints: ["tcp/localhost:7447"]`,
+    `listen.endpoints: ["tcp/localhost:0"]`.
+  - `open.return_conditions: { connect_scouted: true, declares: true }` — open
+    blocks until scouted peers/routers are connected and initial declares are
+    received.
+  - `scouting.multicast.enabled: false`, `scouting.gossip.enabled: true`.
+  - `timestamping.enabled: { router: true, peer: true, client: true }` (needed
+    for advanced pub/sub caching/history to work).
+  - `queries_default_timeout: 600000` (ms) — default `get` timeout (10 min).
+- At context init the RMW also declares a **liveliness subscriber** for the
+  graph cache and performs an initial **liveliness query** (see §3). The router
+  connection attempt count is governed by `ZENOH_ROUTER_CHECK_ATTEMPTS`
+  (0 = wait indefinitely, negative = skip, positive = N attempts at 1 s
+  intervals); initialization proceeds even if no router is found, and the node
+  auto-connects once a router appears.
+
+---
+
+## 2. Key expression scheme (topics and services)
+
+### Exact format
+
+From `docs/design.md` and confirmed by `liveliness_utils.cpp`
+`TopicInfo::TopicInfo` (lines ~77-97):
+
+```
+<domain_id>/<fully_qualified_name>/<type_name>/<type_hash>
+```
+
+Construction code (verbatim intent):
+
+```cpp
+topic_keyexpr_  = std::to_string(domain_id);
+topic_keyexpr_ += "/";
+topic_keyexpr_ += strip_slashes(name_);   // leading/trailing '/' removed
+topic_keyexpr_ += "/";
+topic_keyexpr_ += type_;
+topic_keyexpr_ += "/";
+topic_keyexpr_ += type_hash_;
+```
+
+Fields:
+
+- `<domain_id>` — value of `ROS_DOMAIN_ID` (default `0`). Prefixing with the
+  domain id **prevents cross-domain communication** even on shared routers.
+- `<fully_qualified_name>` — the fully qualified topic/service name *with
+  leading and trailing slashes stripped*, so the internal `/` of a namespace is
+  kept as real Zenoh path separators (namespaces become key hierarchy). NOTE:
+  this is **different** from liveliness tokens, where the name is *mangled*
+  (`/`→`%`). In the *data-plane* topic key expression the slashes are kept.
+- `<type_name>` — DDS-style CDR type name, e.g. `std_msgs::msg::dds_::String_`.
+- `<type_hash>` — REP-2016 type hash from `rosidl`, e.g.
+  `RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18`.
+
+Including type name + type hash **prevents pub/sub (or client/server) with the
+same name but mismatched types from matching**.
+
+### Examples (from design.md)
+
+```
+0/chatter/std_msgs::msg::dds_::String_/RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18
+0/robot1/chatter/std_msgs::msg::dds_::String_/RIHS01_df668c...          (namespace /robot1)
+2/add_two_ints/example_interfaces::srv::dds_::AddTwoInts_/RIHS01_e118de6bf5eeb66a2491b5bda11202e7b68f198d6f67922cf30364858239c81a
+```
+
+Services use the **same** `<domain_id>/<name>/<type>/<hash>` scheme; the service
+type name is the DDS srv type (`..::srv::dds_::AddTwoInts_`).
+
+### Buffer-aware suffixes (GPU / `rosidl::Buffer`)
+
+Optional, only for messages carrying `rosidl::Buffer<T>` fields (native/GPU
+transport). Derived from the base topic key:
+
+| Suffix | Direction | Purpose |
+|--------|-----------|---------|
+| *(none)* | both | Standard CDR-serialized payload; always declared (legacy fallback). |
+| `/_buf_cpu` | pub → sub | Shared CPU-group channel for all CPU-only buffer-aware subscribers. |
+| `/_buf/<sub_gid_hex>` | pub → sub | Per-subscriber accelerated channel; carries only the buffer descriptor for non-CPU backends. |
+
+A Rust backend that does not implement native buffers can ignore these and just
+use the base key.
+
+---
+
+## 3. Discovery — liveliness tokens and the graph cache
+
+### Why
+
+Zenoh does minimal discovery; ROS 2 assumes full graph introspection. Each
+context keeps a **graph cache** of every entity (node, publisher, subscription,
+service server, service client). Each entity, on creation, declares a
+**liveliness token** whose *key expression encodes all of the entity's
+metadata*; on destruction the token is dropped. Peers subscribe to liveliness
+tokens to build/update the cache.
+
+### Liveliness token key expressions
+
+From `docs/design.md` and `liveliness_utils.cpp` (`Entity` constructor and the
+`KeyexprIndex` enum, lines ~161-215, 502-589).
+
+Node token (7 components):
+
+```
+@ros2_lv/<domain_id>/<session_id>/<node_id>/<node_id>/<entity_kind>/<mangled_enclave>/<mangled_namespace>/<node_name>
+```
+
+Publisher / subscription / service server / service client token:
+
+```
+@ros2_lv/<domain_id>/<session_id>/<node_id>/<entity_id>/<entity_kind>/<mangled_enclave>/<mangled_namespace>/<node_name>/<mangled_qualified_name>/<type_name>/<type_hash>/<qos>[/<backends>]
+```
+
+Component order is defined by the `KeyexprIndex` enum:
+
+```
+AdminSpace, DomainId, Zid, Nid, Id, EntityStr, Enclave, Namespace, NodeName,
+TopicName, TopicType, TopicTypeHash, TopicQoS, Backends
+```
+
+Field semantics:
+
+- `@ros2_lv` — constant admin-space prefix (`ADMIN_SPACE`). It marks a Zenoh
+  "hermetic namespace": wildcards `*`/`**` never match this chunk.
+- `<domain_id>` — `ROS_DOMAIN_ID`.
+- `<session_id>` (a.k.a. `Zid`) — the Zenoh session id (one per context).
+- `<node_id>` (`Nid`) — id of the node within the context.
+- `<entity_id>` (`Id`) — id of the entity within the node. For a **node token**
+  the `Nid` and `Id` slots are **both the node id** (hence the duplicated
+  `<node_id>/<node_id>`).
+- `<entity_kind>` (`EntityStr`) — two-letter code:
+  - `NN` node, `MP` message publisher, `MS` message subscription,
+    `SS` service server, `SC` service client.
+- `<mangled_enclave>` — SROS enclave, mangled; `%` if unset.
+- `<mangled_namespace>` — namespace, mangled; `%` if empty (the default).
+- `<node_name>` — node name (mangled, but node names contain no `/`).
+- `<mangled_qualified_name>` — fully qualified topic/service name, mangled.
+- `<type_name>`, `<type_hash>` — as in §2.
+- `<qos>` — compact QoS encoding, see §6.
+- `<backends>` — optional; only for buffer-aware entities. Format
+  `backends:<name>:<meta>;<name>:<meta>` with names sorted lexicographically and
+  fields percent-escaped (`%`→`%25`, `;`→`%3B`, `:`→`%3A`, `/`→`%2F`).
+
+**Name mangling** (`mangle_name`/`demangle_name`): every `/` is replaced by `%`.
+This is required because Zenoh liveliness tokens cannot contain empty chunks
+(`//`) and cannot be empty; an empty namespace is represented as a single `%`.
+(Contrast with §2 topic keys, which keep real slashes.)
+
+### Examples (from design.md)
+
+```
+@ros2_lv/0/aac3178e146ba6f1fc6e6a4085e77f21/0/0/NN/%/%/listener
+@ros2_lv/0/aac3178e146ba6f1fc6e6a4085e77f21/0/10/MS/%/%/listener/%chatter/std_msgs::msg::dds_::String_/RIHS01_df668c.../::,10:,:,:,,
+@ros2_lv/0/8b20917502ee955ac4476e0266340d5c/0/10/MP/%/%/talker/%chatter/std_msgs::msg::dds_::String_/RIHS01_df668c.../::,7:,:,:,,
+@ros2_lv/0/f9980ee0495eaafb3e38f0d19e2eae12/0/10/SS/%/%/add_two_ints_server/%add_two_ints/example_interfaces::srv::dds_::AddTwoInts_/RIHS01_e118de.../::,10:,:,:,,
+@ros2_lv/0/e1dc8d1b45ae8717fce78689cc655685/0/10/SC/%/%/add_two_ints_client/%add_two_ints/example_interfaces::srv::dds_::AddTwoInts_/RIHS01_e118de.../::,10:,:,:,,
+```
+
+Note the topic name is prefixed with a mangled leading slash (`%chatter`),
+because the fully qualified name is `/chatter`.
+
+### Late joiners / initial graph view
+
+- The graph-cache liveliness **subscriber** is declared over the whole domain.
+  The subscription key expression is (`liveliness_utils.cpp` `subscription_token`):
+
+  ```cpp
+  std::string token = std::string(ADMIN_SPACE) + "/" + std::to_string(domain_id) + "/**";
+  // e.g. "@ros2_lv/0/**"
+  ```
+
+- On context init the RMW calls **`Session::liveliness_get`** on that same
+  keyexpr to pull the **current** set of tokens (the existing graph) — this is
+  how a late joiner learns already-present entities. Thereafter the liveliness
+  **subscriber** delivers PUT (entity appeared) / DELETE (entity left) samples
+  to keep the cache live.
+- Zenoh APIs used (design.md "Contexts"/"Graph Cache" → Related Zenoh APIs):
+  `Session::liveliness_declare_token`, `Session::liveliness_declare_subscriber`,
+  `Session::liveliness_get`.
+
+The Rust equivalents are `Session::liveliness().declare_token(...)`,
+`...declare_subscriber(...)`, and `...get(...)`.
+
+---
+
+## 4. Message attachments
+
+Every publication (and every service request/response) carries a Zenoh
+**attachment** with three fields, in this order (from
+`attachment_helpers.cpp` and design.md "Publishers"):
+
+1. **sequence number** — `int64_t`
+2. **source timestamp** — `int64_t`, nanoseconds since UNIX epoch
+3. **source GID** — 16-byte array (`RMW_GID_STORAGE_SIZE == 16`)
+
+The serialization uses `zenoh::ext::Serializer` / `Deserializer`:
+
+```cpp
+zenoh::Bytes AttachmentData::serialize_to_zbytes() {
+  auto serializer = zenoh::ext::Serializer();
+  serializer.serialize(this->sequence_number_);   // int64
+  serializer.serialize(this->source_timestamp_);  // int64
+  serializer.serialize(this->source_gid_);        // std::array<uint8_t,16>
+  return std::move(serializer).finish();
+}
+```
+
+The on-the-wire layout produced by that serializer (documented in design.md) is:
+
+- 8 bytes — sequence number (int64, little-endian)
+- 8 bytes — source timestamp (int64, little-endian)
+- 1 byte — GID length (currently always `16`)
+- 16 bytes — GID (16× int8)
+
+**Rust note:** the `zenoh-ext` serializer prefixes variable-length items (the
+array) with a length. To interoperate byte-for-byte, a Rust backend should use
+the `zenoh_ext` serialization (`zenoh_ext::z_serialize`) or reproduce this exact
+framing (two LE i64 + 1-byte length `16` + 16 bytes), rather than a naive
+concatenation.
+
+Why these fields:
+
+- **sequence number** — correlates service requests to responses; also used for
+  `MESSAGE_LOST` detection on subscriptions.
+- **source timestamp** — populates `rmw_message_info_t.source_timestamp` /
+  request headers.
+- **source GID** — identifies the origin publisher/client (fills
+  `publisher_gid` / `request_id.writer_guid`); on the service side it is hashed
+  to index the pending-request map (§5).
+
+---
+
+## 5. Services (request/response)
+
+Services are implemented with Zenoh **queryables** (server side) and **queriers
+/ `get`** (client side). Both sides declare liveliness tokens (`SS` and `SC`).
+
+### Server (`rmw_service_data.cpp`)
+
+- Declares a **queryable** on the service key expression
+  (`<domain>/<name>/<type>/<hash>`) with:
+  ```cpp
+  QueryableOptions qable_options = ...create_default();
+  qable_options.complete = true;   // no wildcards -> can answer every request
+  session->declare_queryable(keyexpr, on_query_cb, qable_options);
+  ```
+  `complete = true` advertises that this queryable can satisfy any matching
+  query (it maps to `ALL_COMPLETE` on the querier side).
+- Each incoming `zenoh::Query` is wrapped (`ZenohQuery`, with a received
+  timestamp) and pushed on a `query_queue_`. `rmw_take_request` pops it,
+  reads the attachment:
+  - `request_id.sequence_number` ← attachment sequence number.
+  - `request_id.writer_guid` ← attachment source GID (the **client** GID).
+  - `request_header.source_timestamp` ← attachment source timestamp.
+- The pending query is stored in a nested map so the response can find it later:
+  ```
+  sequence_to_query_map_ : hash_gid(client_gid) -> ( sequence_number -> ZenohQuery )
+  ```
+  Key = `hash_gid(writer_guid)` (the client's GID hashed to `size_t`),
+  inner key = sequence number. Duplicate sequence numbers for the same client
+  are rejected.
+- `rmw_send_response` looks up `(hash_gid(request_id.writer_guid),
+  request_id.sequence_number)`, retrieves the stored `Query`, and calls
+  `Query::reply(...)` (Zenoh `reply` operation) with:
+  - the serialized response payload, and
+  - an attachment **echoing the request's sequence number and the client GID**,
+    plus a **fresh source timestamp** for the reply.
+
+### Client (`rmw_client_data.cpp`)
+
+- Declares a **querier** (`Session::declare_querier`) on the service key
+  expression with:
+  ```cpp
+  QuerierOptions options = ...create_default();
+  options.target = Z_QUERY_TARGET_ALL_COMPLETE;                 // only complete queryables
+  options.consolidation = Z_CONSOLIDATION_MODE_NONE;            // allow any number/order of replies
+  // action get_result services get an effectively infinite timeout:
+  if (querier_ke.intersects("**/_action/get_result/**"))
+      options.timeout_ms = std::numeric_limits<uint64_t>::max();
+  ```
+- `rmw_send_request`:
+  - assigns `*sequence_id = sequence_number_++` (client-local counter, starts at 1);
+  - builds attachment `{sequence_id, now_ns, client_entity_gid}` via
+    `entity_->copy_gid()`;
+  - calls `querier_.get(parameters, reply_callback, opts)` with the serialized
+    request as `opts.payload` and the attachment as `opts.attachment`.
+- The reply callback receives `zenoh::Reply`s; each OK reply's `Sample` is
+  wrapped in a `ZenohReply` (with received timestamp) and pushed to
+  `reply_queue_` (bounded by the QoS depth).
+- `rmw_take_response` pops a reply, reads the attachment, and sets
+  `request_header->request_id.sequence_number` from the **reply's** attachment
+  (the server echoed it) — this is how the client matches the response back to
+  its request. `received_timestamp` comes from the wrapper.
+
+### Correlation summary
+
+`sequence_number` (client-assigned, monotonically increasing) plus the client
+`GID` uniquely identify a request. The server keys its pending map by
+`hash_gid(client_gid) -> sequence_number`, and echoes both back in the reply
+attachment so the client can match. Zenoh's query/reply plumbing also ties each
+reply to the originating `get`.
+
+---
+
+## 6. QoS mapping
+
+From `docs/design.md` "Quality of Service" and `liveliness_utils.cpp`
+(`qos_to_keyexpr`, `keyexpr_to_qos`, and the `qos_*_to_str` tables).
+
+General principle: **in Zenoh there are no "incompatible" QoS** — any publisher
+can match any subscription. QoS is (a) enforced/emulated with Zenoh mechanisms
+where it maps naturally, and (b) *encoded into the liveliness token* so the
+graph/introspection layer can report actual QoS and compute matches.
+
+### Behavioural mapping
+
+- **RELIABILITY**
+  - `RELIABLE` (publishers): delivery over a reliable transport (TCP/QUIC) when
+    such endpoints exist.
+  - `BEST_EFFORT`: may drop; uses non-reliable endpoints (e.g. UDP) if
+    configured, else falls back to reliable. Default config only has TCP.
+    `BEST_EFFORT` is also `SYSTEM_DEFAULT`.
+- **HISTORY**
+  - `KEEP_LAST`: subscriptions keep up to `DEPTH` samples; for `TRANSIENT_LOCAL`
+    publishers `DEPTH` sizes the publication cache. `SYSTEM_DEFAULT`.
+  - `KEEP_ALL`: subscriptions keep all; reliable publishers set
+    `CongestionControl::BLOCK` (publisher blocks under congestion → back-pressure).
+- **DEPTH**: max samples for `KEEP_LAST`. **If `DEPTH == 0`, rmw_zenoh uses 42.**
+- **DURABILITY**
+  - `VOLATILE` (default): only live subscriptions receive data.
+  - `TRANSIENT_LOCAL`: late joiners get history. Implemented via the
+    **advanced publisher** with a **publication cache**, and the **advanced
+    subscriber** configured to **query that cache** for historical data on
+    startup. (This is the "querying subscriber" / latched-topic mechanism.)
+- **LIVELINESS**
+  - `AUTOMATIC` only — managed by the RMW via liveliness tokens.
+  - `MANUAL_BY_TOPIC` unsupported.
+- **DEADLINE**, **LIFESPAN**: currently **unimplemented** (values are still
+  carried in the QoS keyexpr, but not enforced).
+
+### Compact QoS encoding in liveliness tokens (`qos_to_keyexpr`)
+
+The `<qos>` component is a **delta encoding against the RMW default QoS**: each
+field is emitted only if it differs from the default, otherwise the slot is left
+empty. Field/separator layout (built in `qos_to_keyexpr`):
+
+```
+<reliability>:<durability>:<history>,<depth>:<deadline_sec>,<deadline_nsec>:<lifespan_sec>,<lifespan_nsec>:<liveliness>,<lease_sec>,<lease_nsec>
+```
+
+- Separators: `:` (`QOS_DELIMITER`) between groups, `,`
+  (`QOS_COMPONENT_DELIMITER`) between sub-fields.
+- Policy enum values are the numeric `rmw_qos_policy_*` codes rendered as
+  decimal strings (e.g. history KEEP_LAST, reliability RELIABLE, etc.).
+- An empty field means "same as default" and is filled from
+  `QoS::get().default_qos()` on decode (`keyexpr_to_qos`).
+
+Worked example — `::,7:,:,:,,`:
+
+- reliability empty (default), durability empty (default),
+- history empty (default) / **depth = 7**,
+- deadline empty/empty, lifespan empty/empty,
+- liveliness empty / lease empty / lease empty.
+
+i.e. only a non-default depth of 7 is encoded (the talker example). The listener
+example `::,10:,:,:,,` encodes only depth 10.
+
+`keyexpr_to_qos` reverses this: it splits on `:` (expects ≥6 groups), splits the
+history/deadline/lifespan/liveliness groups on `,`, and fills empty fields with
+the defaults.
+
+---
+
+## 7. GID (16-byte RMW GID)
+
+Generated in `liveliness_utils.cpp`, `Entity` constructor (lines ~578-589):
+
+- The GID is the **128-bit XXH3 hash of the entity's full liveliness key
+  expression string**:
+  ```cpp
+  simplified_XXH128_hash_t keyexpr_gid =
+      simplified_XXH3_128bits(liveliness_keyexpr_.c_str(), liveliness_keyexpr_.length());
+  memcpy(gid_.data(),      &keyexpr_gid.low64,  8);
+  memcpy(gid_.data() + 8,  &keyexpr_gid.high64, 8);
+  ```
+  So `gid[0..8]` = `low64` and `gid[8..16]` = `high64`, each written in host
+  (little-endian) byte order. Implementation of the hash is in
+  `simplified_xxhash3.cpp` (a self-contained XXH3-128 so the result is stable
+  across platforms/versions).
+- Because the liveliness keyexpr encodes domain, session id, node id, entity id,
+  kind, names, type, and QoS, the GID is **deterministically unique per
+  entity** and identical everywhere it is observed.
+- A second `size_t` hash of the 16-byte GID (`hash_gid`, lines ~860-869) is used
+  as an in-memory map key. `hash_gid` builds a hex string of the bytes and runs
+  `std::hash<std::string>`; it is a *local* index only, not on the wire.
+- Usage: the GID is placed in message attachments as `source_gid`
+  (publisher/client identity), returned to the RMW via
+  `rmw_get_gid_for_publisher` / `rmw_get_gid_for_client`, and used server-side
+  (hashed) to demux pending service requests.
+
+`RMW_GID_STORAGE_SIZE` is 16.
+
+---
+
+## 8. Actions
+
+There is **no action concept at the RMW level** (design.md "Actions"). Actions
+are composed entirely of ordinary **services + topics** at a higher ROS layer,
+so `rmw_zenoh` has **no special Zenoh handling for actions**. The only
+action-aware code is a client-side optimization: queriers whose key expression
+intersects `**/_action/get_result/**` get an effectively infinite `get` timeout
+(`rmw_client_data.cpp`), because `get_result` may block for a long time.
+
+Implication: a Rust backend gets actions "for free" once services and topics
+work; just replicate the `get_result` long-timeout heuristic.
+
+---
+
+## 9. Implications for a Rust `ros2-client` Zenoh backend
+
+Concrete building blocks the Rust `zenoh` (+ `zenoh-ext`) crate must provide,
+and how each maps to what rmw_zenoh does:
+
+**Session / config**
+- `zenoh::open(config)` — one session per ROS context. Load a JSON5 config
+  equivalent to `DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5` (peer mode, connect
+  `tcp/localhost:7447`, listen `tcp/localhost:0`, gossip on, multicast off,
+  timestamping on, `open.return_conditions`). Honor `ZENOH_SESSION_CONFIG_URI`
+  and `ZENOH_CONFIG_OVERRIDE`. Require/expect an external `zenohd` router.
+- Domain isolation is achieved purely by the `<domain_id>/` prefix in every key,
+  not by config.
+
+**Key expressions**
+- Build data-plane keys as `"<domain>/<fqn_no_slashes>/<type_name>/<type_hash>"`
+  (real slashes preserved in the name). Type name in DDS form
+  (`pkg::msg::dds_::Type_`), type hash in `RIHS01_...` form.
+
+**Publish / subscribe**
+- `session.declare_publisher(key)` for volatile; for `TRANSIENT_LOCAL` use the
+  **advanced publisher** with a **publication cache** sized by `DEPTH`
+  (`zenoh_ext` `AdvancedPublisher` / `CacheConfig`).
+- `session.declare_subscriber(key, cb)`; for `TRANSIENT_LOCAL` use the
+  **advanced subscriber** with **history/query-on-startup** to pull cached
+  samples (querying subscriber). Requires session `timestamping.enabled`.
+- Apply congestion control `BLOCK` for `KEEP_ALL` + `RELIABLE` publishers.
+- Every `put` must carry the attachment (§4).
+
+**Attachments**
+- Reproduce the exact `zenoh_ext` serialization of `(i64 seq, i64 ts_ns,
+  [u8;16] gid)` — use `zenoh_ext::z_serialize` (length-prefixed array) for
+  byte compatibility, not a hand-rolled concat.
+
+**Services**
+- Server: `session.declare_queryable(key)` with `complete(true)`; read the
+  request attachment (seq, client gid, ts); keep a
+  `HashMap<gid_hash, HashMap<seq, Query>>` of pending queries; answer with
+  `query.reply(key, payload)` carrying an attachment that echoes seq + client
+  gid and a fresh timestamp.
+- Client: `session.declare_querier(key)` (or `session.get`) with
+  `target = ALL_COMPLETE`, `consolidation = None`; monotonically increasing
+  per-client `sequence_number` starting at 1; attach `(seq, ts, client_gid)`;
+  correlate replies by the echoed sequence number.
+- Long timeout for `**/_action/get_result/**`.
+
+**Liveliness / discovery**
+- Declare a **liveliness token** per entity (node/pub/sub/service/client) with
+  the exact key format and component order from §3, including name mangling
+  (`/`→`%`, empty→`%`) and the compact QoS encoding from §6.
+- Declare a **liveliness subscriber** on `@ros2_lv/<domain>/**` and run an
+  initial **liveliness get** on the same key to seed the graph cache; process
+  PUT/DELETE to maintain it.
+- Rust APIs: `session.liveliness().declare_token(key)`,
+  `session.liveliness().declare_subscriber(key)`,
+  `session.liveliness().get(key)`.
+
+**GID**
+- Compute the 16-byte GID as XXH3-128 of the entity's liveliness keyexpr string
+  (low64 then high64, LE), so GIDs match rmw_zenoh peers exactly. Use a
+  stable/simplified XXH3-128 implementation.
+
+**QoS**
+- Encode/decode the compact `<qos>` delta-vs-default string. Maintain a single
+  canonical "default QoS profile" identical to rmw_zenoh's so the delta encoding
+  interoperates. Treat DEADLINE/LIFESPAN as carried-but-not-enforced;
+  LIVELINESS AUTOMATIC only; `DEPTH==0` → 42.
+
+**Not needed for a first cut**
+- Buffer-aware (`/_buf_cpu`, `/_buf/<gid>`) native/GPU transport — optional; the
+  base key path fully interoperates.
+- Shared-memory optimization — transparent, not required for correctness.
+</content>
+</invoke>

--- a/docs/zenoh_study/research/ros2_client_internals.md
+++ b/docs/zenoh_study/research/ros2_client_internals.md
@@ -1,0 +1,525 @@
+# `ros2-client` internals: a feature-by-feature architecture map
+
+Scope: this document maps how each ROS 2 feature in the `ros2-client` crate is
+implemented, and pinpoints every place the implementation depends on RustDDS.
+The goal is to enable adding a second backend (Zenoh) behind the same public API.
+Citations are `file:line`. `context.rs` and `pubsub.rs` are documented
+separately; this file references them only where `Node` uses them.
+
+RustDDS is imported crate-wide with glob imports (`use rustdds::*;`) in almost
+every module, so DDS types appear unqualified (`GUID`, `Topic`, `Timestamp`,
+`QosPolicies`, `SequenceNumber`, `Duration`, `SampleInfo`, ...). The whole of
+RustDDS is also re-exported (`pub use rustdds;` in `src/lib.rs:139`), and a
+curated subset is re-exported under the `ros2::` module (`src/lib.rs:126-135`).
+
+---
+
+## 0. RustDDS surface used (quick index)
+
+Types/methods from RustDDS that the client couples to (detailed per feature
+below):
+
+- `DomainParticipant` (via `Context`), `DomainParticipantStatusEvent`, `.status_listener()`, `.as_async_status_stream()`
+- `Topic`, `TopicKind::NoKey`, `DomainParticipant::create_topic(...)`
+- `no_key::DataWriter`, `no_key::SimpleDataReader`, `no_key::DeserializedCacheChange`, `no_key::DeserializerAdapter`/`SerializerAdapter`/`DefaultDecoder`/`Decode`
+- `Publisher`/`Subscriber` (inside `pubsub.rs`, not read here, but wrapped)
+- `GUID`, `GUID::to_bytes()`, `GUID::from_bytes()`
+- `QosPolicies`, `QosPolicyBuilder`, `policy::*` (`Reliability`, `History`, `Durability`, `Deadline`, `Ownership`, `Lifespan`), `Duration`
+- `Timestamp` (RTPS `Time_t`), `Timestamp::now()`, `Timestamp::ZERO`, `Timestamp::INVALID/INFINITE`, `.to_ticks()`
+- `rpc::SampleIdentity`, `rpc::SequenceNumber`
+- `WriteOptionsBuilder`, `.source_timestamp()`, `.related_sample_identity()`
+- `SampleInfo` (`.source_timestamp()`, `.publication_handle()`, `.sample_identity()`, `.related_sample_identity()`)
+- `RepresentationIdentifier` (`CDR_LE`, `CDR_BE`), `serialization::{to_writer_with_rep_id, deserialize_from_cdr_with_rep_id}`
+- `dds::key::{Key, CdrEncodingSize}`
+- error types `CreateError/CreateResult`, `ReadError/ReadResult`, `WriteError/WriteResult`
+- `mio::Evented` (register/reregister/deregister) implemented by `Client`/`Server`
+
+---
+
+## 1. Context (how Node uses it)
+
+`Context` wraps the RustDDS `DomainParticipant` and is documented separately.
+`Node` holds a `Context` (`ros_context: Context`, `src/node.rs:626`) and calls
+into it for all entity creation. The `Context` methods `Node` relies on:
+
+- `ros_context.domain_participant()` -> `&DomainParticipant` (used directly for service topic creation, `src/node.rs:1332,1339,1384,1391`, and by `Spinner` for the status listener, `src/node.rs:182`)
+- `create_topic`, `create_publisher`, `create_subscription`, `create_simpledatareader`, `create_datawriter` (`src/node.rs:1243,1258,1276,1290,1303`)
+- `get_parameter_events_topic()`, `get_rosout_topic()`, `ros_discovery_topic()` (`src/node.rs:675,676,186`)
+- `update_node(NodeEntitiesInfo)`, `remove_node(&str)` — ROS-graph discovery publishing (`src/node.rs:923,1593`)
+- `domain_id()`, `clone()` (`Context` is cheaply clonable / shared)
+
+Key point for the port: `Context` is the single chokepoint that owns the
+`DomainParticipant`. A Zenoh backend would replace `Context`'s internals (a
+Zenoh `Session`) and re-expose the same creation methods.
+
+---
+
+## 2. Node
+
+Central file `src/node.rs` (~1778 lines).
+
+### Public API
+- `Node::new(NodeName, NodeOptions, Context)` (crate-internal; produced by `Context::new_node`), `src/node.rs:670`
+- `create_topic`, `create_subscription`, `create_publisher` (`src/node.rs:1236,1253,1271`)
+- `create_client`, `create_server` (`src/node.rs:1315,1367`)
+- `create_action_client`, `create_action_server` (`src/node.rs:1410,1487`)
+- `spinner()` -> `Spinner`; `Spinner::spin().await` (`src/node.rs:784`, `:180`)
+- `status_receiver() -> Receiver<NodeEvent>` (`src/node.rs:1112`)
+- `wait_for_reader`/`wait_for_writer` (crate-internal, `src/node.rs:1127,1149`)
+- `get_publisher_count`/`get_subscription_count` (crate-internal, `src/node.rs:1175,1188`)
+- Parameter API: `set_parameter`, `get_parameter`, `has_parameter`, `list_parameters`, `undeclare_parameter` (`src/node.rs:960-1058`)
+- `time_now()` (sim-time aware), `logging_handle()`, `rosout_subscription()`, `domain_id()`, `fully_qualified_name()`
+
+### Reader/writer bookkeeping
+`Node` tracks entities it created in two `BTreeSet<Gid>`: `readers` and
+`writers` (`src/node.rs:630-631`). Every `create_*` call funnels through
+`add_reader`/`add_writer` (`src/node.rs:927,934`), which insert the entity's
+`Gid` (converted from its DDS `GUID` via `.guid().into()`, e.g.
+`src/node.rs:1259,1277`) and then re-publish the node's ROS graph info via
+`ros_context.update_node(self.generate_node_info())`.
+
+`generate_node_info()` (`src/node.rs:897`) builds a `NodeEntitiesInfo` from the
+`Gid`s of the parameter-events writer, rosout writer, and all tracked
+readers/writers. `suppress_node_info_updates` (`AtomicBool`, `src/node.rs:633`)
+batches updates during construction to avoid flooding.
+
+Separately, `Node` maintains DDS-match maps updated by the spinner:
+`readers_to_remote_writers` and `writers_to_remote_readers`, both
+`Arc<Mutex<BTreeMap<GUID, BTreeSet<GUID>>>>` (`src/node.rs:640-641`). Keys are
+local entity GUIDs; values are matched remote entity GUIDs. These drive
+`get_publisher_count`/`get_subscription_count` and the `wait_for_*` futures.
+
+### Spinner / spin
+`Spinner` (`src/node.rs:145`) is the background event loop, produced by
+`node.spinner()` and driven by `.spin().await` (`src/node.rs:180`). It is a big
+`futures::select!` loop (`src/node.rs:227-452`) over:
+
+1. `stop_spin_receiver` (async_channel) — shutdown.
+2. **DDS discovery events**: `dds_status_stream` = `domain_participant().status_listener().as_async_status_stream()` (`src/node.rs:182-184`). Matches `DomainParticipantStatusEvent::{RemoteReaderMatched, RemoteWriterMatched, ReaderLost, WriterLost}` and updates the two match maps (`src/node.rs:420-447`). Every event is also forwarded to status listeners as `NodeEvent::DDS(...)`.
+3. **ROS discovery events**: a subscription to the `ros_discovery_info` topic of type `ParticipantEntitiesInfo` (`src/node.rs:186-191`). On update it stores `part_update.node_entities_info_seq` keyed by `Gid` in `external_nodes` and forwards `NodeEvent::ROS(...)`.
+4. **Simulated clock**: subscription to `/clock` (`builtin_interfaces::Time`), stored into `sim_time` (`src/node.rs:193-197,233-242`).
+5. **Parameter service requests** (six servers): each server exposes `receive_request_stream()`; the spinner answers `get/set/list/describe/...` (`src/node.rs:200-398`).
+
+`NodeEvent` (`src/node.rs:124`) is the public discovery event enum with two
+variants: `DDS(DomainParticipantStatusEvent)` and `ROS(ParticipantEntitiesInfo)`.
+**Both variants leak DDS/RTPS concepts** (`DomainParticipantStatusEvent` is a
+RustDDS type; `ParticipantEntitiesInfo` carries `Gid`s).
+
+### ROS graph event / status stream API
+`status_receiver()` (`src/node.rs:1112`) registers an `async_channel::Sender`
+into `status_event_senders` and returns the `Receiver<NodeEvent>`. The spinner
+fans out events via `send_status_event` (`src/node.rs:459`), pruning closed
+channels. Panics if no spinner is running.
+
+### wait_for_reader / wait_for_writer
+`wait_for_writer(reader_guid)` / `wait_for_reader(writer_guid)`
+(`src/node.rs:1127,1149`) return custom futures `WriterWait`/`ReaderWait`
+(`src/node.rs:1649,1707`). They first check the match maps; if already matched,
+resolve immediately (`Ready`), else poll the `status_receiver()` stream for the
+matching `DomainParticipantStatusEvent::RemoteReaderMatched`/`RemoteWriterMatched`
+whose `local_writer`/`local_reader` equals the given `GUID`
+(`src/node.rs:1674-1684,1735-1745`). Used by `Client::wait_for_service`.
+
+### get_subscription_count etc.
+`get_subscription_count(publisher_guid)` = length of the matched-readers set for
+that writer GUID; `get_publisher_count(subscription_guid)` = matched-writers set
+size (`src/node.rs:1175-1199`).
+
+### DDS coupling in Node
+- Match maps keyed by **`GUID`** and populated only from `DomainParticipantStatusEvent` (`src/node.rs:640-641,420-447`).
+- `NodeEvent::DDS` exposes RustDDS `DomainParticipantStatusEvent` publicly.
+- `wait_for_*` take `GUID` and depend on RTPS reader/writer matching semantics.
+- Service topic creation calls `domain_participant().create_topic(..., TopicKind::NoKey)` directly (`src/node.rs:1332-1345,1384-1396`).
+- QoS for parameter services built with `QosPolicyBuilder`/`policy::Reliability`/`History`/`Duration` (`src/node.rs:792-797`).
+- `NodeCreateError::DDS(CreateError)` wraps RustDDS creation errors (`src/node.rs:574`).
+
+---
+
+## 3. Topics & naming (`src/names.rs`) — critical for Zenoh key expressions
+
+This is the DDS name-mangling layer. Two axes: **topic names** (with kind
+prefixes `rt/`, `rq/`, `rr/`) and **type names** (with `dds_` infix and trailing
+`_`).
+
+### Types
+- `NodeName { namespace, base_name }` (`src/names.rs:16`) — `fully_qualified_name()` = `namespace + "/" + base_name` (`src/names.rs:86`).
+- `Name { base_name, preceeding_tokens: Vec<String>, absolute: bool }` (`src/names.rs:126`) — a topic/service name split into tokens, with an `absolute` flag (leading `/`). Constructed via `Name::new(namespace, base_name)` or `Name::parse("a/b/c")` (`src/names.rs:146,212`).
+- `MessageTypeName { prefix, ros2_package_name, ros2_type_name }` (`src/names.rs:295`); `prefix` defaults to `"msg"` (or `"action"`).
+- `ServiceTypeName { prefix, msg }` (`src/names.rs:343`); `prefix` defaults to `"srv"` (or `"action"`).
+- `ActionTypeName(MessageTypeName)` (`src/names.rs:396`).
+
+### Topic-name mangling — `Name::to_dds_name(kind_prefix, node, suffix)` (`src/names.rs:239`)
+Algorithm:
+1. Start with `kind_prefix` (e.g. `"rt"`, `"rq"`, `"rr"`); asserts it does not end with `/`.
+2. If the `Name` is **relative**, append the node's namespace (`node.namespace()`); if **absolute**, do not.
+3. Append `/`.
+4. Append each preceding token followed by `/`.
+5. Append `base_name`, then `suffix`.
+
+Result examples:
+- `create_topic` uses `kind_prefix="rt"`, `suffix=""` (`src/node.rs:1242`): topic `/turtle1/cmd_vel` -> `rt/turtle1/cmd_vel`.
+- Service request topic: `to_dds_name("rq", node, "Request")` (`src/node.rs:1333,1386`).
+- Service response topic: `to_dds_name("rr", node, "Reply")` (`src/node.rs:1340,1391`). **Note the suffix is `"Reply"`, not `"Response"`** (the code even comments on this oddity, `src/node.rs:1330`).
+
+Prefix meanings (ROS 2 `topic_and_service_names` design doc):
+- `rt/` — regular topics (ROS "topic")
+- `rq/` — service request
+- `rr/` — service reply/response
+- `rs/` — service (used by some RMWs for the "service" concept; **not emitted by this crate** — it only uses `rt`/`rq`/`rr`).
+
+### Type-name mangling
+- `MessageTypeName::dds_msg_type()` (`src/names.rs:330`):
+  `slash_to_colons(package + "/" + prefix + "/dds_/" + type + "_")`.
+  e.g. `std_msgs/String` -> `std_msgs::msg::dds_::String_`.
+- `ServiceTypeName::dds_request_type()` / `dds_response_type()` (`src/names.rs:371,382`):
+  `package + "/" + prefix + "/dds_/" + type + "_Request_"` (resp. `_Response_`),
+  colon-joined. e.g. `example_interfaces/AddTwoInts` ->
+  `example_interfaces::srv::dds_::AddTwoInts_Request_` / `..._Response_`.
+- `slash_to_colons` (`src/names.rs:337`) simply replaces `/` with `::`.
+- Action type names (`src/names.rs:411-427`):
+  - `dds_action_topic(topic)` -> `MessageTypeName` with prefix `"action"` and type `<Type><topic>` (e.g. topic `"_FeedbackMessage"` -> type `<pkg>::action::dds_::<Type>_FeedbackMessage_`).
+  - `dds_action_service(srv)` -> `ServiceTypeName` with prefix `"action"` and type `<Type><srv>` (e.g. `"_SendGoal"` -> `<pkg>::action::dds_::<Type>_SendGoal_Request_`).
+
+### DDS coupling in naming
+The mangling itself is pure string manipulation (no RustDDS types), so it ports
+cleanly. **But**: the `rt/`/`rq/`/`rr/` prefixes and the `dds_`/`_Request_`
+suffixes are the DDS wire convention. For Zenoh interop you must reproduce the
+**same** mangled strings as key expressions (`rmw_zenoh` uses a specific keyexpr
+format: `<domain>/<mangled_topic>/<type>/<type_hash>`), so this module is the
+canonical source of the topic/type string format and should be reused/adapted
+rather than reinvented. `to_dds_name` is the function to mirror.
+
+---
+
+## 4. Pub/Sub QoS
+
+`QosPolicies` (RustDDS) is used directly and is part of the public API of
+`create_topic`/`create_publisher`/`create_subscription` (`src/node.rs:1236-1279`;
+`qos: &QosPolicies` / `Option<QosPolicies>`). Built-in topic QoS profiles are
+defined in `src/builtin_topics.rs` with `QosPolicyBuilder` and `policy::*`:
+
+- `ros_discovery::QOS_PUB/QOS_SUB` (`src/builtin_topics.rs:6-26`): TransientLocal/Volatile durability, `Deadline(INFINITE)`, `Ownership::Shared`, `reliable(ZERO)`, `History::KeepLast{depth:1}`, `Lifespan{INFINITE}`.
+- `parameter_events::QOS` (`:36-42`): TransientLocal, reliable, KeepLast(1).
+- `rosout::QOS` (`:52-63`): TransientLocal, reliable, KeepLast(1), `Lifespan{10s}`.
+
+Node passes `None` to inherit topic QoS, or an explicit `QosPolicies`. Service
+QoS in `spinner()` built inline (`src/node.rs:792`).
+
+### DDS coupling
+`QosPolicies`, `QosPolicyBuilder`, and every `policy::*` variant are RustDDS
+types exposed directly in the public API (also re-exported via
+`ros2::{policy, QosPolicies, QosPolicyBuilder, Duration}`, `src/lib.rs:127`).
+The DDS QoS model (Durability, Ownership, Deadline, Lifespan, History,
+Reliability with `max_blocking_time`) does not map 1:1 to Zenoh. This is a major
+public-API coupling point.
+
+---
+
+## 5. Services (`src/service/`)
+
+### ServiceMapping (`src/service/mod.rs:98-118`)
+Enum with three variants selecting the RPC-over-DDS wire mapping:
+- `Basic` — OMG DDS-RPC "Basic": each request/response carries a CDR header struct (`BasicRequestHeader{ request_id: SampleIdentity, instance_name: String }`, `BasicReplyHeader{ related_request_id: SampleIdentity, remote_exception_code: u32 }`, `src/service/wrappers.rs:253-284`). Correlation via **payload-embedded `SampleIdentity`**.
+- `Enhanced` — OMG DDS-RPC "Enhanced": **no** payload header; correlation via **DDS inline-QoS `related_sample_identity`** (RTPS). Used by eProsima/rmw_fastrtps and RTI extended mapping. This is the default the crate uses for parameter services (`src/node.rs:804`).
+- `Cyclone` — CycloneDDS-specific, reverse-engineered. Payload header `CycloneHeader{ guid_second_half: [u8;8], sequence_number_high: i32, sequence_number_low: u32 }` (`src/service/wrappers.rs:293-313`) — only the **last 8 bytes** of the client GUID travel in the header; the other 8 bytes are reconstructed from the DDS `writer_guid` of the received sample.
+
+### Types & public API
+- `Service` trait pairs `Request`/`Response` (`: Message`) with type-name accessors (`src/service/mod.rs:25`). `AService<Q,S>` is a runtime constructor (`:38`).
+- `Client<S>` (`src/service/client.rs:16`): `send_request`/`async_send_request` -> `RmwRequestId`; `receive_response`/`async_receive_response(req_id)`; `async_call_service`; `wait_for_service`.
+- `Server<S>` (`src/service/server.rs:18`): `receive_request`/`async_receive_request`/`receive_request_stream` -> `(RmwRequestId, Request)`; `send_response`/`async_send_response(rmw_req_id, Response)`.
+
+### Topic naming for services
+`create_client`/`create_server` (`src/node.rs:1315,1367`) each create two DDS
+topics with `TopicKind::NoKey`:
+- request topic: name `to_dds_name("rq", node, "Request")`, type `dds_request_type()`
+- reply topic: name `to_dds_name("rr", node, "Reply")`, type `dds_response_type()`
+
+### Internal implementation
+`Client` holds a `DataWriterR<RequestWrapper<Req>>` (request_sender) and a
+`SimpleDataReaderR<ResponseWrapper<Resp>>` (response_receiver)
+(`src/service/client.rs:22-27`); `Server` is the mirror
+(`src/service/server.rs:24-27`). `DataWriterR`/`SimpleDataReaderR` are aliases
+for `no_key::DataWriter`/`no_key::SimpleDataReader` with custom pass-through
+serializer adapters (`src/service/wrappers.rs:345-347`).
+
+The (de)serializer adapters (`ServiceSerializerAdapter`/`ServiceDeserializerAdapter`,
+`src/service/wrappers.rs:349-408`) do **no** real (de)serialization — they hand
+raw bytes to the `Wrapper` types, because the `ServiceMapping` (needed to
+generate/parse headers) is only known at the `Wrapper` layer, not at the RustDDS
+adapter layer. `WrapperDecoder::decode_bytes` just wraps bytes + `RepresentationIdentifier`.
+
+### Request-ID / correlation (the heart of the DDS coupling)
+- `RmwRequestId { writer_guid: GUID, sequence_number: SequenceNumber }` (`src/service/request_id.rs:9`) — structurally **identical** to RustDDS `rpc::SampleIdentity`, with `From` conversions both ways (`src/service/request_id.rs:14-40`).
+- On send, the client generates `RmwRequestId` from its own **request-writer GUID** (`client_guid = request_sender.guid()`, `src/service/client.rs:55`) plus a locally incremented atomic `SequenceNumber` (`src/service/client.rs:67-72,222-233`).
+- `WriteOptionsBuilder` (`src/service/client.rs:79-85`): always sets `source_timestamp(Timestamp::now())`; for `Basic`/`Cyclone` also sets `related_sample_identity(SampleIdentity::from(gen_rmw_req_id))`. For `Enhanced`, it relies on the DDS stack to fill related sample identity and returns the **actually-sent** `RmwRequestId` from `write_with_options` (`.map(RmwRequestId::from)`), i.e. the real RTPS sequence number.
+- Wire encoding per mapping in `RequestWrapper::new`/`unwrap` and `ResponseWrapper::new`/`unwrap` (`src/service/wrappers.rs:46-249`):
+  - **Basic**: prepend `BasicRequestHeader`/`BasicReplyHeader` (contains `SampleIdentity`) to CDR payload.
+  - **Enhanced**: payload only; on receive, `RmwRequestId` comes from `message_info.related_sample_identity()` (inline QoS). Fallbacks for FastDDS quirks: if missing, use `sample_identity()`; if `sequence_number == SequenceNumber::UNKNOWN`, patch it with the actual DATA submessage sequence number (`src/service/wrappers.rs:74-99,191-197`).
+  - **Cyclone**: prepend `CycloneHeader`; on decode, reconstruct the full 16-byte client GUID from header (8 bytes) + received sample's `writer_guid` (8 bytes) (`src/service/wrappers.rs:199-216,317-343`).
+- The server echoes correlation back: `send_response`/`async_send_response` set `related_sample_identity(SampleIdentity::from(rmw_req_id))` in `WriteOptions` for **all** mappings (plus the payload header for Basic/Cyclone) (`src/service/server.rs:94-107,167-181`).
+- `MessageInfo` (`src/message_info.rs`) extracts `source_timestamp`, `sequence_number`, `publisher` (`publication_handle()`), and `related_sample_identity` from RustDDS `SampleInfo` / `DeserializedCacheChange`. This is the bridge that surfaces RTPS correlation metadata into the service layer.
+
+### `mio::Evented`
+`Client` and `Server` implement `mio::Evented` by delegating to the underlying
+RustDDS `SimpleDataReader` (`src/service/client.rs:277-300`,
+`src/service/server.rs:184-207`) for readiness-based (non-async) polling.
+
+### DDS coupling in Services (severe)
+- Correlation is fundamentally `GUID` + RTPS `SequenceNumber` (`RmwRequestId` == `SampleIdentity`).
+- `Enhanced` mapping depends on RTPS **inline-QoS related_sample_identity** — a wire feature with no Zenoh equivalent.
+- `Cyclone` mapping reconstructs GUIDs by splicing DDS `writer_guid` bytes.
+- `WriteOptionsBuilder`/`related_sample_identity`/`source_timestamp` are RustDDS write-path types.
+- Public API returns/consumes `RmwRequestId` (contains `GUID`, `SequenceNumber`), and errors are `ReadError`/`WriteError`.
+- `RepresentationIdentifier` (CDR_LE/BE) and `serialization::*` are RustDDS CDR helpers.
+
+---
+
+## 6. Actions (`src/action.rs`, `src/action/{client,server}.rs`)
+
+Actions are **composed entirely from 3 services + 2 topics** — there is no
+new DDS mechanism, so actions inherit exactly the service/pubsub coupling.
+
+### Composition (built in `Node::create_action_client`/`create_action_server`, `src/node.rs:1410-1560`)
+Given `action_name` (e.g. `/turtle1/rotate_absolute`) and `ActionTypeName`
+(e.g. `turtlesim/RotateAbsolute`), the base name is `action_name.push("_action")`.
+Sub-entities:
+
+| Sub-entity | Kind | Name (via `Name::push`) | Type |
+|---|---|---|---|
+| send_goal | Service (Client/Server) | `<action>/_action/send_goal` | `dds_action_service("_SendGoal")` -> `<pkg>::action::dds_::<Type>_SendGoal_Request_`/`_Response_` |
+| cancel_goal | Service | `<action>/_action/cancel_goal` | `action_msgs/CancelGoal` (`ServiceTypeName::new("action_msgs","CancelGoal")`) |
+| get_result | Service | `<action>/_action/get_result` | `dds_action_service("_GetResult")` |
+| feedback | Topic (Sub on client / Pub on server) | `<action>/_action/feedback` | `dds_action_topic("_FeedbackMessage")` -> `<pkg>::action::dds_::<Type>_FeedbackMessage_` |
+| status | Topic | `<action>/_action/status` | `action_msgs/GoalStatusArray` |
+
+Note `Name::push` (`src/names.rs:259`) moves the current base name into
+preceding tokens and sets a new base — so `/turtle1/rotate_absolute` + `_action`
++ `send_goal` produces topic `rq/turtle1/rotate_absolute/_action/send_goal...`.
+Concrete expected DDS strings are enumerated in comments at
+`src/action.rs:144-165`.
+
+### IDL-equivalent message types (`src/action.rs:105-142`)
+- `SendGoalRequest<G>{ goal_id: GoalId, goal: G }`, `SendGoalResponse{ accepted: bool, stamp: Time }`
+- `GetResultRequest{ goal_id }`, `GetResultResponse<R>{ status: GoalStatusEnum, result: R }`
+- `FeedbackMessage<F>{ goal_id, feedback: F }`
+- Uses `action_msgs::{CancelGoalRequest, CancelGoalResponse, GoalId, GoalInfo, GoalStatusEnum, GoalStatusArray}`.
+- `GoalId` is a `unique_identifier_msgs::UUID`, generated with `UUID::new_random()` (`src/action/client.rs:84,125`) — **application-level correlation**, independent of DDS GUIDs.
+
+### Client (`src/action/client.rs`)
+Wraps three `Client<AService<...>>` and two `Subscription<...>`
+(`src/action/client.rs:32-44`). `send_goal` sends a random `GoalId`; correlation
+of goal responses uses the **service** `RmwRequestId`, while feedback/status/result
+are correlated by the application-level `GoalId` (filtering streams by
+`goal_id`, `src/action/client.rs:245-335`).
+
+### Server (`src/action/server.rs`)
+`ActionServer` (sync) wraps three `Server<...>` + two `Publisher<...>`.
+`AsyncActionServer` (`src/action/server.rs:268`) adds a goal state machine
+(`GoalStatusEnum` transitions Unknown->Accepted->Executing->Succeeded/Aborted/Canceled)
+in synchronous `Mutex<BTreeMap<GoalId, AsyncGoal>>`, buffering result requests by
+`GoalId` until the goal finishes (`src/action/server.rs:552-597`). Handle types
+`NewGoalHandle`/`AcceptedGoalHandle`/`ExecutingGoalHandle` enforce state via the
+type system; each carries the service `RmwRequestId` for eventually responding.
+
+### DDS coupling in Actions
+Only indirect: everything goes through Services (see §5 coupling) and Pub/Sub
+(§4 QoS). `GoalId`-based correlation is application-level and **ports cleanly**.
+`ActionClientQosPolicies`/`ActionServerQosPolicies` (`src/action.rs:88-103`)
+expose five `QosPolicies` fields each — DDS QoS in the public API.
+
+---
+
+## 7. Parameters (`src/parameters.rs`)
+
+### Public API
+`ParameterValue` (Rust enum, `src/parameters.rs:20`), `Parameter`,
+`ParameterType`, `ParameterDescriptor`, `NumericRange`, `SetParametersResult =
+Result<(), String>`. Node methods `set_parameter`/`get_parameter`/etc. (§2).
+
+### Wire types (`src/parameters.rs:291-383`, module `raw`)
+Serde structs mirroring `rcl_interfaces` msgs: `ParameterEvent`, `Parameter`,
+`ParameterValue` (flat struct with all typed fields), `SetParametersResult`,
+`ParameterDescriptor`, `IntegerRange`, `FloatingPointRange`. `From` impls convert
+between the ergonomic enums and the flat `raw` structs.
+
+### Implementation
+- **Parameter services**: six `Server<rcl_interfaces::*>` created inside `spinner()` (`src/node.rs:803-858`) using `ServiceMapping::Enhanced` and node-qualified names (`get_parameters`, `get_parameter_types`, `set_parameters`, `set_parameters_atomically`, `list_parameters`, `describe_parameters`). Requests are handled in the spinner select loop (§2). So parameter services are ordinary ROS 2 services — same DDS coupling as §5.
+- **parameter_events topic**: a `Publisher<raw::ParameterEvent>` on topic `rt/parameter_events` (name+QoS from `src/builtin_topics.rs:33-47`), created in `Node::new` (`src/node.rs:681`). Every `set_parameter`/`undeclare_parameter` publishes a `raw::ParameterEvent` (`src/node.rs:552-561,966-977,1020-1029`).
+- `raw::ParameterEvent.timestamp` is a RustDDS `Timestamp` (`src/parameters.rs:298`); populated with `rustdds::Timestamp::now()` in `Spinner::set_parameter` (`src/node.rs:555`) or `self.time_now().into()` in `Node::set_parameter`.
+- `use_sim_time` is a built-in parameter (declared in `Node::new`, `src/node.rs:685`); setting it toggles `use_sim_time: AtomicBool` which switches `time_now()` between `ROSTime::now()` and the `/clock`-fed `sim_time` (`src/node.rs:764-770,510-516`).
+
+### DDS coupling in Parameters
+Only via §5 (services use `ServiceMapping::Enhanced`, i.e. RTPS related sample
+identity) and the `Timestamp` field type in `raw::ParameterEvent`. The enum/raw
+conversion layer is DDS-agnostic.
+
+---
+
+## 8. rosout logging (`src/rosout.rs`, `src/builtin_topics.rs`)
+
+### Public API
+`RosoutRaw` trait (`src/rosout.rs:11`) with `rosout_raw(timestamp, level,
+log_name, log_msg, file, function, line)`; implemented by `Node`
+(`src/node.rs:1597`) and `NodeLoggingHandle` (`src/rosout.rs:77`, a `Send`-able
+handle). The `rosout!` macro (`src/node.rs:1626`) is the ergonomic entry point.
+
+### Implementation
+`rosout_raw` publishes a `log::Log` message (`rcl_interfaces::msg::Log`) via a
+`Publisher<Log>` and also emits a `tracing` event (`src/rosout.rs:41-63`). The
+publisher lives in `Node.rosout_writer: Arc<Option<Publisher<Log>>>`
+(`src/node.rs:651`), created in `Node::new` on topic `rt/rosout`
+(name/type/QoS from `src/builtin_topics.rs:49-68`). Optional inbound
+`rosout_reader: Option<Subscription<Log>>` if `read_rosout(true)`.
+`Log.timestamp` is `ros2::Timestamp` (RustDDS `Timestamp`), passed by the macro
+as `Timestamp::now()` (`src/node.rs:1631`).
+
+### DDS coupling in rosout
+Just ordinary pub/sub plus the `Timestamp` type in the message and macro. Ports
+cleanly modulo the `Timestamp` type.
+
+---
+
+## 9. Discovery (`src/entities_info.rs`, `ros_discovery_info` topic)
+
+### The ROS graph model
+ROS 2 maps **many Nodes to one DDS DomainParticipant**. Discovery of the ROS
+graph (which nodes exist, which readers/writers they own) is published on a
+dedicated topic `ros_discovery_info` (`src/builtin_topics.rs:28`), type
+`rmw_dds_common::msg::dds_::ParticipantEntitiesInfo_` (`:30`).
+
+### Types
+- `ParticipantEntitiesInfo { gid: Gid, node_entities_info_seq: Vec<NodeEntitiesInfo> }` (`src/entities_info.rs:26`) — one DomainParticipant's `Gid` + all ROS nodes it hosts.
+- `NodeEntitiesInfo { name: NodeName, reader_gid_seq: Vec<Gid>, writer_gid_seq: Vec<Gid> }` (`src/entities_info.rs:59`) — a node and the `Gid`s of its readers/writers. Serialized via a `repr::NodeEntitiesInfo` shadow struct with flat `node_namespace`/`node_name` strings (`src/entities_info.rs:129-142`), using serde `try_from`/`into`.
+
+### Assembly of the local ROS graph
+Each `Node` builds its own `NodeEntitiesInfo` in `generate_node_info()`
+(`src/node.rs:897`) from its tracked reader/writer `Gid`s (§2), and pushes it to
+`Context::update_node(...)`. `Context` (elsewhere) aggregates all local nodes
+into one `ParticipantEntitiesInfo` (keyed by the participant `Gid`) and publishes
+it on `ros_discovery_info` with `ros_discovery::QOS_PUB` (TransientLocal,
+reliable). On `Node::drop`, `Context::remove_node(fqn)` is called
+(`src/node.rs:1593`).
+
+### Consumption
+`Spinner` subscribes to `ros_discovery_info` (`src/node.rs:186-191`) and stores
+remote participants' node lists in `external_nodes: BTreeMap<Gid,
+Vec<NodeEntitiesInfo>>` (`src/node.rs:405-408`), also forwarding `NodeEvent::ROS`.
+So the ROS node list / topic list is assembled by merging these
+`ParticipantEntitiesInfo` messages — this is a data-topic-based discovery, layered
+on top of DDS SPDP/SEDP discovery (which separately drives the
+`DomainParticipantStatusEvent` match maps).
+
+### How GUIDs become Gids
+Every entity's RustDDS `GUID` is converted to `Gid` at registration
+(`.guid().into()`, §2). Participant identity is also a `Gid` (from the
+participant's GUID). See §10.
+
+### DDS coupling in Discovery
+- `ros_discovery_info` topic and its `rmw_dds_common` type are the DDS-RMW discovery convention; a Zenoh backend uses `rmw_zenoh`'s liveliness-token-based graph discovery instead (different mechanism entirely).
+- `Gid` values are DDS GUIDs (16/24 bytes), meaningful only in the RTPS world.
+- The dual-source model (data-topic `ParticipantEntitiesInfo` + RTPS `DomainParticipantStatusEvent`) is DDS-specific.
+
+---
+
+## 10. Gid (`src/gid.rs`)
+
+### Format
+`Gid([u8; GID_LENGTH])` (`src/gid.rs:29`). Length is **feature-gated**:
+`16` bytes for `iron`-or-newer, `24` bytes for galactic/humble
+(`src/gid.rs:9-12`) — the ROS 2 `rmw_dds_common` `Gid.msg` changed size in
+Jan 2023 (between Humble and Iron). Debug prints as hex.
+
+### Relationship to RustDDS GUID
+- `From<GUID> for Gid` (`src/gid.rs:40-46`): copies `guid.to_bytes()` into the array, zero-padding if `GID_LENGTH > 16` (a DDS `GUID` is 16 bytes, so the 24-byte format is 16 bytes of GUID + 8 zero bytes).
+- `From<Gid> for GUID` (`src/gid.rs:48-52`): takes the first 16 bytes.
+- `impl Key for Gid {}` (`src/gid.rs:54`) and `derive(CdrEncodingSize)` — RustDDS keyed-topic traits, so `Gid` can be a DDS key.
+
+### DDS coupling in Gid
+`Gid` **is** a DDS GUID (16 bytes) with padding, and implements RustDDS `Key`/
+`CdrEncodingSize`. It is used pervasively in `NodeEntitiesInfo` and the public
+`ParticipantEntitiesInfo`. For Zenoh, entity identity would instead be a Zenoh
+`ZenohId`/entity id; `rmw_zenoh` fabricates GUID-shaped ids to keep the
+`rmw_dds_common` graph format, so the `Gid` type may survive as an opaque
+16-byte id but its provenance changes.
+
+---
+
+## DDS-isms that won't survive a Zenoh port
+
+Concrete coupling points, roughly in order of severity:
+
+1. **Service RPC correlation = RTPS `SampleIdentity` (`GUID` + `SequenceNumber`).**
+   `RmwRequestId` is byte-identical to `rpc::SampleIdentity`
+   (`src/service/request_id.rs`). The `Enhanced` mapping relies on RTPS
+   **inline-QoS `related_sample_identity`** carried out-of-band by the DDS stack
+   (`src/service/wrappers.rs:74-99,186-197`; `src/service/{client,server}.rs`
+   `WriteOptionsBuilder::related_sample_identity`). Zenoh has no inline QoS —
+   correlation must move into the payload (like Basic/Cyclone) or use a
+   Zenoh query/reply. All three `ServiceMapping` variants are DDS wire mappings.
+
+2. **`WriteOptions` / `related_sample_identity` / `source_timestamp` write path.**
+   `WriteOptionsBuilder` is RustDDS-only (`src/service/client.rs:79-90`,
+   `src/service/server.rs:94-107,167-181`). No Zenoh analogue for related sample
+   identity; source timestamp must be modeled manually.
+
+3. **DDS discovery coupling (dual mechanism).**
+   (a) `DomainParticipantStatusEvent` stream + `RemoteReader/WriterMatched`,
+   `Reader/WriterLost` drive the match maps and `wait_for_reader/writer` and the
+   pub/sub counts (`src/node.rs:182-184,420-447,1127-1199`). (b) The
+   `ros_discovery_info` data topic with `rmw_dds_common::ParticipantEntitiesInfo`
+   (`src/entities_info.rs`, `src/builtin_topics.rs:28-31`). `rmw_zenoh` replaces
+   both with liveliness tokens. `NodeEvent::DDS(DomainParticipantStatusEvent)` is
+   a public API leak of a RustDDS type.
+
+4. **`GUID`-based identity everywhere.**
+   Match maps keyed by `GUID` (`src/node.rs:640-641`); `wait_for_*` take `GUID`
+   (`src/node.rs:1127,1149`); `Gid` is a padded DDS GUID (`src/gid.rs`);
+   `MessageInfo.publisher`/`writer_guid` = RTPS `publication_handle`
+   (`src/message_info.rs:23-46`); Cyclone mapping splices GUID byte halves
+   (`src/service/wrappers.rs:199-216,301-311`).
+
+5. **RustDDS QoS types in the public API.**
+   `QosPolicies`, `QosPolicyBuilder`, `policy::*`, `Duration` appear in
+   `create_topic/publisher/subscription`, `create_client/server`, action QoS
+   structs, and are re-exported via `ros2::` (`src/lib.rs:127`). The DDS QoS
+   model (Durability/Ownership/Deadline/Lifespan/Reliability-with-max_blocking_time)
+   has no clean Zenoh mapping.
+
+6. **RustDDS `Timestamp` (RTPS `Time_t`) in message/metadata types.**
+   `raw::ParameterEvent.timestamp` (`src/parameters.rs:298`), `log::Log.timestamp`,
+   `rosout!` macro, `MessageInfo` timestamps, and the `ROSTime<->Timestamp`
+   conversions (`src/ros_time.rs:86-133`) all use RustDDS `Timestamp`. Re-exported
+   as `ros2::Timestamp`.
+
+7. **Topic-kind prefixes and CDR type-name mangling are the DDS wire format.**
+   `rt/`/`rq/`/`rr/` and `<pkg>::<kind>::dds_::<Type>_[Request_|Response_]`
+   (`src/names.rs`). Not RustDDS *types*, but the DDS naming convention;
+   `rmw_zenoh` needs the same mangled strings inside its keyexpr format (plus a
+   type hash and domain id), so this must be adapted, not dropped.
+
+8. **RustDDS error types in signatures.**
+   `CreateError/Result`, `ReadError/Result`, `WriteError/Result` (and
+   `NodeCreateError::DDS`, `GoalError::DDS*`, `CallServiceError`) are RustDDS
+   `dds::*` types threaded through nearly every public method and re-exported via
+   `ros2::` (`src/lib.rs:129`).
+
+9. **RustDDS (de)serialization + representation identifiers.**
+   `RepresentationIdentifier::{CDR_LE,CDR_BE}`,
+   `serialization::{to_writer_with_rep_id, deserialize_from_cdr_with_rep_id}`,
+   and the `no_key::{DataWriter, SimpleDataReader, DeserializerAdapter,
+   SerializerAdapter, DefaultDecoder, Decode, DeserializedCacheChange}` adapter
+   machinery (`src/service/wrappers.rs`). CDR is the DDS wire encoding; the whole
+   pass-through-adapter design exists to inject `ServiceMapping` header handling.
+
+10. **`mio::Evented` sync polling.**
+    `Client`/`Server` expose `mio` readiness registration delegating to the
+    RustDDS `SimpleDataReader` (`src/service/client.rs:277-300`,
+    `src/service/server.rs:184-207`) — tied to RustDDS's mio integration.
+
+11. **`Gid` implements RustDDS `Key`/`CdrEncodingSize`** and its length is
+    ROS-distro/feature gated to match DDS GUID conventions (`src/gid.rs`).
+
+Things that **do** port cleanly: the `names.rs` string algorithms (pure string
+ops), the parameter enum<->raw conversion layer, action `GoalId`-based
+correlation (application-level UUIDs), `ROSTime`/`ROSDuration` arithmetic, and
+the message/IDL struct definitions themselves (plain serde).

--- a/docs/zenoh_study/research/workshop_use_cases.md
+++ b/docs/zenoh_study/research/workshop_use_cases.md
@@ -1,0 +1,351 @@
+# ROS 2 Use Cases from the ZettaScaleLabs RosCon 2025 Workshop
+
+Source repository: <https://github.com/ZettaScaleLabs/roscon2025_workshop>
+
+This document catalogues the concrete ROS 2 use cases exercised by the
+ZettaScaleLabs "ROS 2 over Zenoh" (`rmw_zenoh`) workshop, so they can be turned
+into smoke tests for a Rust ROS 2 client (`ros2-client`) that talks over Zenoh.
+
+The workshop is built around the standard ROS 2 demo nodes and CLI, but with
+`rmw_zenoh_cpp` as the middleware. The valuable payload for us is the set of
+plain ROS 2 interactions (topics, services, actions, graph introspection) that
+these nodes perform, plus the exact Zenoh middleware configuration they run
+under.
+
+---
+
+## 1. Overview, prerequisites and setup
+
+### What the workshop is
+
+A hands-on workshop teaching participants to run ROS 2 (Jazzy) over Zenoh using
+`rmw_zenoh`. It progresses from a trivial talker/listener up to a full Nav2 +
+Gazebo + RViz2 simulation, and then explores Zenoh transport features (shared
+memory, remote connectivity, mTLS, wireless tuning, congestion control, internet
+traversal).
+
+- README: <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/README.md>
+
+### Hardware / environment prerequisites
+
+- Linux, macOS or Windows laptop; 8 cores, 16 GB RAM, 30 GB free disk.
+- Docker configured with an 8 CPU / 16 GB memory limit.
+- Pre-pull the Docker image `zettascaletech/roscon2025_workshop`
+  (multi-arch: amd64 + arm64).
+
+### How Zenoh + ROS 2 are launched
+
+- `docker compose up -d` starts **two containers**, both running ROS 2 Jazzy
+  from the same image:
+  - **robot** container — VNC at <http://localhost:6080/>, IP `172.1.0.2`
+  - **control** container — VNC at <http://localhost:6081/>, IP `172.1.0.3`
+  - VNC unlock password: `ubuntu`
+  - Custom bridge network `sim_network`, subnet `172.1.0.0/16`.
+  - Zenoh ports exposed: `7447` (TCP/UDP).
+  - Each container mounts a host volume at `~/container_data`
+    (`container_volumes/robot_container` and
+    `container_volumes/control_container`).
+  - Containers grant `NET_ADMIN`, `seccomp:unconfined`, `rtprio: 99`, and
+    ~640 MB `/dev/shm` for the shared-memory exercises.
+  - docker-compose: <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/docker-compose.yaml>
+    (a `docker-compose-common-shm.yaml` variant also exists for shared memory).
+
+### Key environment variables (middleware config)
+
+- `RMW_IMPLEMENTATION=rmw_zenoh_cpp` — set in both containers by default. This is
+  the switch that makes ROS 2 use Zenoh instead of DDS.
+- `ZENOH_ROUTER_CONFIG_URI` — path to the Zenoh **router** config file.
+- `ZENOH_SESSION_CONFIG_URI` — path to the Zenoh **session** (ROS node) config file.
+- `ZENOH_CONFIG_OVERRIDE` — inline `key/path=value;...` overrides applied *after*
+  the config file is loaded. Example:
+  `export ZENOH_CONFIG_OVERRIDE="scouting/multicast/enabled=true"`.
+- `ROS_DOMAIN_ID` — used in the internet-traversal exercise to isolate multiple
+  robots sharing one cloud router (`export ROS_DOMAIN_ID=123456`).
+- A helper script `~/workshop_env.bash` sets `ZENOH_ROUTER_CONFIG_URI` /
+  `ZENOH_SESSION_CONFIG_URI` automatically when
+  `~/container_data/ROUTER_CONFIG.json5` / `SESSION_CONFIG.json5` exist.
+
+### The Zenoh router (`rmw_zenohd`)
+
+- Started with: `ros2 run rmw_zenoh_cpp rmw_zenohd`
+- Role: a **discovery service** for nodes on the same host. When a node starts it
+  tries to connect to the local router; the router shares each node's locators
+  (IP + port) via a gossip protocol so nodes then form **direct peer-to-peer**
+  connections. Once peers are connected, the router is no longer needed for them
+  to communicate — you can `CTRL+C` the router and talker/listener keep going.
+- The router can be started *after* the nodes; nodes retry periodically.
+- **Multicast vs unicast discovery:** default discovery is via the router
+  (unicast). Multicast scouting can be enabled to let nodes discover each other
+  *without a router*, via
+  `ZENOH_CONFIG_OVERRIDE='scouting/multicast/enabled=true'`.
+- Default config files ship with `rmw_zenoh_cpp`:
+  - `DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5` (router)
+  - `DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5` (all ROS processes)
+  - Located at `/opt/ros/${ROS_DISTRO}/share/rmw_zenoh_cpp/config/`
+    (or `~/rmw_zenoh/install/rmw_zenoh_cpp/share/rmw_zenoh_cpp/config/` in the
+    workshop's from-source build).
+  - Notable fields: `connect` (endpoints to dial), `listen` (endpoints to accept
+    on), `scouting` (discovery), `mode` (`peer` vs `client`), `transport`
+    (shared memory, compression, TLS, QoS).
+
+### The `just` wrapper
+
+Later exercises drive the heavy simulation through a `justfile` in the home
+directory rather than raw `ros2` commands. Relevant recipes:
+`just router`, `just rox_simu [no_gui] [use_wall_time:=True]`, `just rox_nav2`,
+`just rviz_nav2`, `just cam_latency [image]`, `just top`, `just iftop_lo`,
+`just iftop_router`, `just rt_factor`, `just network_limit`, `just network_normal`.
+
+---
+
+## 2. Exercise-by-exercise catalogue
+
+### Exercise 1 — Zenoh router and ROS nodes
+
+- Doc: <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-1.md>
+- ROS 2 features demonstrated: **topic pub/sub, service client/server, action
+  client/server, graph introspection**, and middleware discovery behavior.
+- Message/service/action types: `std_msgs/msg/String` (talker/listener),
+  `example_interfaces/srv/AddTwoInts` (add_two_ints),
+  `action_tutorials_interfaces/action/Fibonacci` (fibonacci action).
+- Exact commands:
+  - Router: `ros2 run rmw_zenoh_cpp rmw_zenohd`
+  - Talker: `ros2 run demo_nodes_cpp talker`
+  - Listener: `ros2 run demo_nodes_cpp listener`
+  - Multicast-only discovery (no router):
+    `ZENOH_CONFIG_OVERRIDE='scouting/multicast/enabled=true' ros2 run demo_nodes_cpp talker`
+    (and the same prefix for `listener`)
+  - Service server: `ros2 run demo_nodes_cpp add_two_ints_server`
+  - Service client: `ros2 run demo_nodes_cpp add_two_ints_client`
+  - Action server: `ros2 run action_tutorials_cpp fibonacci_action_server`
+  - Action client: `ros2 run action_tutorials_cpp fibonacci_action_client`
+  - Introspection: `ros2 node list`, `ros2 topic list`, `ros2 service list`,
+    `ros2 action list`
+- Notable detail: the `ros2` CLI keeps working even with the router stopped
+  because the ROS 2 daemon is itself a peer node that caches the graph.
+
+### Exercise 2 — Complete simulation with Nav2
+
+- Doc: <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-2.md>
+- ROS 2 features: full navigation stack — many topics (LaserScan, camera
+  image + point cloud, map, odometry, `/tf`), Nav2 actions (goal poses), RViz2
+  visualization. Robot: Neobotix ROX; simulator: Gazebo; nav: Navigation2.
+- Commands are wrapped by `just`: `just router`, `just rox_simu` (`no_gui` for
+  headless), `just rox_nav2`, `just rviz_nav2`, plus metrics recipes
+  (`just top`, `just iftop_lo`, `just rt_factor`, `just cam_latency`).
+- Navigation goals are issued interactively via RViz2 ("Nav2 goal" tool), which
+  under the hood sends a `nav2_msgs`/`geometry_msgs` action goal. No raw
+  `ros2 action send_goal` is shown, but the mechanism is a ROS 2 action.
+- Note: running with `use_wall_time:=True` disables Nav2.
+
+### Exercise 3 — Shared memory
+
+- Doc: <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-3.md>
+- Focus: Zenoh transport, not new ROS 2 API surface. Enable
+  `transport/shared_memory.enabled = true` in `ROUTER_CONFIG.json5` and
+  `SESSION_CONFIG.json5`; size via
+  `transport/shared_memory/transport_optimization/pool_size` (≥ 2× total
+  published message size). Verify by inspecting `.zenoh` files in `/dev/shm`.
+- Reuses the Nav2 simulation (`just router`, `just rox_simu use_wall_time:=True`,
+  `just cam_latency [image]`) to measure image / point-cloud latency.
+
+### Exercise 4 — Remote connectivity
+
+- Doc: <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-4.md>
+- Focus: cross-host Zenoh. The robot router listens on `tcp/[::]:7447`; remote
+  hosts reach it at `tcp/172.1.0.2:7447`.
+  - Solution 1 — cascaded routers: control container's router adds a
+    `connect.endpoints: ["tcp/172.1.0.2:7447"]`.
+  - Solution 2 — direct node as `mode: "client"` with the same connect endpoint
+    in `SESSION_CONFIG.json5`.
+  - Override example:
+    `ZENOH_CONFIG_OVERRIDE='mode="client";connect/endpoints=["tcp/173.1.0.2:7447"];transport/shared_memory/enabled=true'`
+- ROS 2 payload is the same Nav2 / RViz2 topics streamed to a remote viewer.
+- **Directly relevant to a Zenoh client:** demonstrates `peer` vs `client` mode
+  and explicit unicast connect endpoints — exactly what a `ros2-client` over
+  Zenoh must support.
+
+### Exercise 5 — Securing communication with mTLS
+
+- Doc: <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-5.md>
+- Focus: transport security. Generate a root CA + robot/control certs
+  (`smallstep/step-cli`). Router listens on `tcp/localhost:7447` (internal) and
+  `tls/172.1.0.2:7447` (external); control connects via `tls/172.1.0.2:7447`.
+  `transport/link/tls` block with `root_ca_certificate`, listen/connect
+  key+cert, `enable_mtls: true`, `verify_name_on_connect: false`. QUIC
+  (`quic/...`) offered as an encrypted UDP alternative.
+- No new ROS 2 API; same topic/graph traffic over an encrypted link.
+
+### Exercise 6 — Tuning for wireless networks
+
+- Doc: <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-6.md>
+- Focus: bandwidth reduction — LZ4 compression
+  (`transport/unicast/compression.enabled`), Zenoh **access control** (allow/deny
+  rules on key expressions, e.g. block point-cloud topics), and **downsampling**
+  (e.g. cap camera image publications to 3 Hz on egress). Mentions Zenoh
+  primitives: `put`, `reply`, `declare_subscriber/queryable`,
+  `liveliness_token/query`, and TRANSIENT_LOCAL advertising.
+- Commands: `just router`, `just rox_simu`, `just rox_nav2`, `just rviz_nav2`,
+  `just iftop_router`.
+
+### Exercise 7 — Congestion and head-of-line blocking
+
+- Doc: <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-7.md>
+- Focus: QoS priority mapping and congestion control in `ROUTER_CONFIG.json5`.
+  8 Zenoh priority levels (`control`, `real_time`, `interactive_high`,
+  `interactive_low`, `data_high`, `data`, `data_low`, `background`); map
+  `**/map/**` & `**/scan/**` to `interactive_high`, `**/camera/points/**` to
+  `background`; switch large payloads from `congestion_control: drop` to
+  `block_first`. Emulate WiFi with `just network_limit` / `just network_normal`,
+  verify with `ping 172.1.0.3`.
+
+### Exercise 8 — Internet traversal
+
+- Doc: <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-8.md>
+- Focus: a cloud-hosted Zenoh router as a NAT/firewall rendezvous
+  (`quic/roscon.zenoh.io:7447`); both robot and control set
+  `connect/endpoints` to it. Multi-robot conflict resolution via ROS
+  namespaces + `/tf` remap, `ROS_DOMAIN_ID` (`export ROS_DOMAIN_ID=123456`), or a
+  Zenoh `namespace: "<name>"` in `SESSION_CONFIG.json5` (transparent key-expr
+  prefix; adjust router patterns `*/camera/` → `**/camera/`).
+
+---
+
+## 3. Testable use cases (workshop-derived scenarios)
+
+Phrased as smoke-test scenarios for `ros2-client` over Zenoh. Each should be
+runnable against a stock `rmw_zenoh_cpp` peer (the C++ demo nodes) to prove
+wire-level interop, and/or between two `ros2-client` instances.
+
+1. **Topic publish → external subscriber receives.** Publish
+   `std_msgs/msg/String` on `/chatter` (like `demo_nodes_cpp talker`) and have
+   `ros2 topic echo /chatter` (or a `demo_nodes_cpp listener`) receive the
+   messages.
+2. **Topic subscribe from external publisher.** Subscribe to `/chatter` and
+   receive the `std_msgs/msg/String` stream produced by `demo_nodes_cpp talker`.
+3. **Round-trip talker/listener between two clients.** One `ros2-client`
+   publishes, another subscribes; assert message content and monotonic counter.
+4. **Discovery via router.** Start `ros2 run rmw_zenoh_cpp rmw_zenohd`, then
+   bring up pub/sub; assert they discover each other through the router
+   (unicast).
+5. **Discovery without router (multicast scouting).** With
+   `ZENOH_CONFIG_OVERRIDE='scouting/multicast/enabled=true'` and no router,
+   pub/sub still find each other; assert delivery.
+6. **Router-independence after peering.** After pub/sub are connected, stop the
+   router; assert messages keep flowing (peer-to-peer already established).
+7. **Service call — AddTwoInts.** Call `/add_two_ints`
+   (`example_interfaces/srv/AddTwoInts`) with `a` and `b`; assert
+   `sum == a + b`. Test as client against `add_two_ints_server`, and as server
+   answering `add_two_ints_client`.
+8. **Action goal — Fibonacci.** Send a Fibonacci goal
+   (`action_tutorials_interfaces/action/Fibonacci`, `order = N`); assert
+   feedback (`partial_sequence`) arrives and the final result is the full
+   Fibonacci sequence of length N. Test both as action client (vs
+   `fibonacci_action_server`) and as action server (vs `fibonacci_action_client`).
+9. **Graph introspection — node list.** `ros2 node list` returns the running
+   node(s) published by `ros2-client`.
+10. **Graph introspection — topic list.** `ros2 topic list` includes the topics
+    a `ros2-client` node advertises (with correct types via `ros2 topic list -t`).
+11. **Graph introspection — service list.** `ros2 service list` includes a
+    service a `ros2-client` node exposes.
+12. **Graph introspection — action list.** `ros2 action list` includes an action
+    a `ros2-client` node exposes.
+13. **Client mode + explicit connect endpoint.** Run a `ros2-client` node in
+    Zenoh `client` mode with `connect/endpoints=["tcp/<host>:7447"]` and confirm
+    pub/sub/service/action still work through a single router uplink (Exercise 4).
+14. **Cross-host over cascaded routers.** Two hosts, each with a router, one
+    connecting to the other's `tcp/<ip>:7447`; assert a topic published on host A
+    is received on host B.
+15. **QoS / TRANSIENT_LOCAL durability.** A late-joining subscriber to a
+    TRANSIENT_LOCAL topic (e.g. a latched `/map`-style topic) receives the last
+    published sample (implied by Exercises 6–7).
+16. **ROS_DOMAIN_ID isolation.** Two node sets on different `ROS_DOMAIN_ID`
+    values do not see each other's topics; same domain do (Exercise 8).
+
+(Exercises 3, 5, 6, 7, 8 also imply transport-level scenarios — shared memory,
+mTLS/QUIC links, compression, priority mapping, congestion control — but these
+are Zenoh-config concerns rather than ROS 2 client API assertions, so they are
+out of scope for the core smoke tests and listed here only for completeness.)
+
+---
+
+## 4. Basic ROS 2 CLI use cases to cover explicitly
+
+These are the baseline CLI interactions the user wants a `ros2-client`-over-Zenoh
+to satisfy. For each: the client feature it exercises and what a smoke test
+should assert. All assume `RMW_IMPLEMENTATION=rmw_zenoh_cpp` on the CLI side and
+a running `rmw_zenohd` (or multicast scouting).
+
+| CLI command | ros2-client feature exercised | Smoke test assertion |
+|---|---|---|
+| `ros2 topic list` | Topic advertisement + discovery/graph publication | The client's advertised topic name(s) appear in the CLI output (with type via `-t`). |
+| `ros2 topic pub /chatter std_msgs/msg/String "{data: hi}"` | Subscriber reception from an external publisher | A client subscriber receives the published `std_msgs/String` samples. |
+| `ros2 topic echo /chatter` | Publisher visibility to an external subscriber | Client-published messages are printed by `echo` with correct content/type. |
+| `ros2 node list` | Node liveliness / graph participation | The client's node name appears in the listed nodes. |
+| `ros2 service list` | Service server advertisement in the graph | A service the client exposes appears (type via `ros2 service list -t`). |
+| `ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts "{a: 2, b: 3}"` | Service server request handling + response | Client service server returns `sum: 5`; response reaches the caller. |
+| `ros2 param list` / `ros2 param get` / `ros2 param set` | Parameter services (`list/get/set_parameters`, describe, `parameter_events`) on a node | Client node exposes parameters; get returns declared values; set updates them and (optionally) emits a `parameter_events` message. |
+| `ros2 action send_goal /fibonacci action_tutorials_interfaces/action/Fibonacci "{order: 5}" --feedback` | Action server: goal accept, feedback, result | Goal is accepted, feedback (`partial_sequence`) is streamed, and final result sequence returned. |
+
+Notes on the parameter case: the workshop does not exercise `ros2 param`
+explicitly, but it is on the user's required list. It exercises the ROS 2
+parameter service interfaces (`rcl_interfaces/srv/{ListParameters, GetParameters,
+SetParameters, DescribeParameters, GetParameterTypes}` and the
+`rcl_interfaces/msg/ParameterEvent` topic on `/parameter_events`), which a
+`ros2-client` node must serve to be introspectable/tunable via the CLI.
+
+---
+
+## 5. Standard interface packages / types to reuse in tests
+
+Well-known, stable types so tests need no custom message packages:
+
+- **`std_msgs`** — `std_msgs/msg/String` (talker/listener `/chatter`). Also
+  `Int32`, `Header` as generic building blocks.
+- **`example_interfaces`** — `example_interfaces/srv/AddTwoInts` (the
+  `add_two_ints` service). Modern ROS 2 also ships
+  `example_interfaces/action/Fibonacci`.
+- **`action_tutorials_interfaces`** — `action_tutorials_interfaces/action/Fibonacci`
+  (the `fibonacci_action_*` nodes used in Exercise 1).
+- **`geometry_msgs`** — `geometry_msgs/msg/Twist`, `PoseStamped`,
+  `Twist`/`TwistStamped` (navigation / velocity commands in the Nav2 exercise).
+- **`sensor_msgs`** — `sensor_msgs/msg/{LaserScan, Image, PointCloud2}`
+  (Nav2 / camera exercises; large-payload cases in 3, 6, 7).
+- **`nav_msgs`** — `nav_msgs/msg/{Odometry, OccupancyGrid}` (`/map`, odometry in Nav2).
+- **`tf2_msgs`** — `tf2_msgs/msg/TFMessage` on `/tf` and `/tf_static`
+  (transforms; namespace/remap concerns in Exercise 8).
+- **`rcl_interfaces`** — parameter services + `/parameter_events` (for the
+  `ros2 param` CLI cases).
+- **`turtlesim`** — not used by this workshop, but the canonical ROS 2 tutorial
+  package (`turtlesim/msg/Pose`, `geometry_msgs/msg/Twist` on
+  `/turtle1/cmd_vel`, `turtlesim/srv/Spawn`, `/turtle1/rotate_absolute` action).
+  Listed because the user named it as a reusable well-known type source; a
+  turtlesim-based test would exercise topic + service + action together.
+
+### Standard nodes used by the workshop (test counterparts)
+
+- `demo_nodes_cpp`: `talker`, `listener`, `add_two_ints_server`,
+  `add_two_ints_client`.
+- `action_tutorials_cpp`: `fibonacci_action_server`, `fibonacci_action_client`.
+- `rmw_zenoh_cpp`: `rmw_zenohd` (the Zenoh router).
+
+These C++ reference nodes make ideal interop counterparts: run the stock node on
+one side and the `ros2-client` implementation on the other to prove wire
+compatibility over Zenoh.
+
+---
+
+## Source URLs
+
+- Repo root / README: <https://github.com/ZettaScaleLabs/roscon2025_workshop>,
+  <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/README.md>
+- docker-compose: <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/docker-compose.yaml>
+- Exercise 1 (router + nodes, topics/services/actions/introspection):
+  <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-1.md>
+- Exercise 2 (Nav2 simulation): <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-2.md>
+- Exercise 3 (shared memory): <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-3.md>
+- Exercise 4 (remote connectivity): <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-4.md>
+- Exercise 5 (mTLS): <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-5.md>
+- Exercise 6 (wireless tuning): <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-6.md>
+- Exercise 7 (congestion / head-of-line blocking): <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-7.md>
+- Exercise 8 (internet traversal): <https://github.com/ZettaScaleLabs/roscon2025_workshop/blob/main/exercises/ex-8.md>

--- a/docs/zenoh_study/research/zenoh_api.md
+++ b/docs/zenoh_study/research/zenoh_api.md
@@ -1,0 +1,714 @@
+# Zenoh Rust API Reference (for a ROS 2 middleware backend)
+
+> **Target version:** `zenoh` / `zenoh-ext` **1.9.0** (current stable 1.x line, released ~2026).
+> All code below targets the **1.x** API. The API changed drastically between 0.x and 1.0
+> (builders, `ZBytes`, `Encoding`, session lifetime, liveliness, `zenoh-ext` advanced pub/sub),
+> so 0.x snippets on the web will **not** compile against 1.x. Pin the version.
+>
+> Primary sources:
+> - Crate docs: <https://docs.rs/zenoh/1.9.0/zenoh/> (and `latest`: <https://docs.rs/zenoh/latest/zenoh/>)
+> - `zenoh-ext` docs: <https://docs.rs/zenoh-ext/latest/zenoh_ext/>
+> - Repo + examples: <https://github.com/eclipse-zenoh/zenoh/tree/main/examples/examples>
+> - `zenoh-ext` examples: <https://github.com/eclipse-zenoh/zenoh/tree/main/zenoh-ext/examples/examples>
+
+---
+
+## 1. Crate dependency, features, async/sync, compile considerations
+
+### Cargo.toml
+
+```toml
+[dependencies]
+# Core. `unstable` unlocks liveliness, matching listeners, advanced APIs, etc.
+zenoh = { version = "1.9.0", features = ["unstable"] }
+# Extended: AdvancedPublisher/AdvancedSubscriber (transient-local-like), serialization helpers.
+zenoh-ext = { version = "1.9.0", features = ["unstable"] }
+# You provide the async runtime yourself:
+tokio = { version = "1", features = ["full"] }
+```
+
+### Key cargo features (from `zenoh/Cargo.toml`)
+
+- `default` = a set of transports: `transport_tcp`, `transport_udp`, `transport_tls`,
+  `transport_quic`, `transport_ws`, `transport_unixsock-stream`, `transport_compression`,
+  `transport_multilink`, plus `auth_pubkey`, `auth_usrpwd`.
+- **`unstable`** — REQUIRED for a ROS-2-style backend. Gates: **liveliness**,
+  `matching_listener`, `SampleKind` in some paths, `Reliability` selection on subscribers,
+  and the whole `zenoh-ext` advanced pub/sub surface. Without it these examples won't compile.
+- `shared-memory` — SHM transport + `zenoh::shm` provider API (large-payload zero-copy).
+- Optional transports you may want to *disable* to cut compile time: `transport_quic`,
+  `transport_ws`, `transport_serial`, `transport_vsock`, `transport_unixpipe`.
+- `internal` / `internal_config` — expose internal config plumbing (rarely needed).
+
+### Async vs sync
+
+Every terminal builder implements `IntoFuture`, so `.await` is the async form.
+The **same** builder also implements `zenoh::Wait`, giving a blocking `.wait()`:
+
+```rust
+use zenoh::Wait;
+let session = zenoh::open(config).wait().unwrap();          // sync
+let publisher = session.declare_publisher("k").wait().unwrap();
+publisher.put(data).wait().unwrap();
+// async equivalents just use .await instead of .wait()
+```
+
+- The runtime is **tokio** (zenoh depends on `tokio` with `["macros","rt","time"]`).
+  You do **not** need `async-std`; 1.x standardized on tokio internally.
+- Zenoh spins up its **own** internal tokio runtime for its background I/O, so `.wait()`
+  works even outside an async context. But if you call the async (`.await`) API you must be
+  inside *your* runtime (`#[tokio::main]` or a manually built runtime). Mixing a blocking
+  `.wait()` on the zenoh runtime *inside* a tokio worker thread can deadlock — prefer `.await`
+  when already async.
+- Handlers (`recv_async`) use the `flume` channel internally.
+
+### Compile-time note
+
+`zenoh` is a large crate with a deep dependency tree (QUIC/TLS via rustls, protocol, transport,
+config). A cold build is heavy. Trim `default-features = false` + only the transports you use to
+speed builds. Docs: <https://docs.rs/zenoh/latest/zenoh/> (crate-level "Cargo Features").
+
+---
+
+## 2. Config & Session
+
+Type: `zenoh::Config` (re-export of `zenoh_config::Config`).
+Docs: <https://docs.rs/zenoh/latest/zenoh/config/struct.Config.html>
+
+Config is edited as a JSON5 document via string paths. There is no large typed builder;
+you mutate paths with `insert_json5`.
+
+```rust
+use zenoh::config::{Config, WhatAmI};
+use serde_json::json;
+
+// Start from defaults, a file, or a JSON5 string:
+let mut config = Config::default();
+// let mut config = Config::from_file("zenoh.json5").unwrap();
+// let mut config = Config::from_json5(r#"{ mode: "peer" }"#).unwrap();
+
+// Session mode: "peer" (default), "client", or "router".
+config.insert_json5("mode", &json!("peer").to_string()).unwrap();
+
+// Explicit endpoints to connect to (e.g. a known router or peer):
+config.insert_json5("connect/endpoints", &json!(["tcp/192.168.1.10:7447"]).to_string()).unwrap();
+
+// Endpoints to listen on (so others can connect to us):
+config.insert_json5("listen/endpoints", &json!(["tcp/0.0.0.0:0"]).to_string()).unwrap();
+
+// --- Scouting / discovery (peer-to-peer, no router needed) ---
+// Multicast UDP scouting (auto-discover peers on the LAN):
+config.insert_json5("scouting/multicast/enabled", &json!(true).to_string()).unwrap();
+config.insert_json5("scouting/multicast/address", &json!("224.0.0.224:7446").to_string()).unwrap();
+// Gossip scouting (peers exchange the peers they know about):
+config.insert_json5("scouting/gossip/enabled", &json!(true).to_string()).unwrap();
+// Disable multicast scouting (e.g. rely on explicit connect endpoints):
+// config.insert_json5("scouting/multicast/enabled", &json!(false).to_string()).unwrap();
+
+// --- No router required ---
+// In "peer" mode with gossip+multicast scouting, peers form a mesh directly; a router is
+// optional. To force full-mesh peer connectivity (each peer connects to each other peer):
+config.insert_json5("routing/peer/mode", &json!("linkstate").to_string()).unwrap();
+
+// Enable timestamping (needed for AdvancedPublisher caching / transient_local, section 8):
+config.insert_json5("timestamping/enabled", &json!(true).to_string()).unwrap();
+```
+
+Config methods (docs: link above):
+- `Config::default() -> Config`
+- `Config::from_file<P: AsRef<Path>>(path) -> ZResult<Config>`
+- `Config::from_json5(&str) -> Result<Config, ...>`
+- `config.insert_json5(key: &str, value: &str) -> ZResult<()>` — set any path.
+- `config.get_json(key: &str) -> ZResult<String>` — read a path back.
+- Typed accessors exist too, e.g. `config.timestamping.set_enabled(Some(ModeDependentValue::Unique(true)))` (used by the advanced-pub example).
+
+`WhatAmI` (mode enum): `WhatAmI::Peer | Client | Router`.
+Docs: <https://docs.rs/zenoh/latest/zenoh/config/enum.WhatAmI.html>
+
+### Opening a session
+
+```rust
+// zenoh::open(config) -> OpenBuilder;  .await -> ZResult<Session>
+let session: zenoh::Session = zenoh::open(config).await.unwrap();
+```
+
+- `zenoh::open(config)` — <https://docs.rs/zenoh/latest/zenoh/fn.open.html>
+- `Session` — <https://docs.rs/zenoh/latest/zenoh/struct.Session.html>
+- **The `Session` is the anchor.** It is internally `Arc`-based and `Clone`; cloning is cheap
+  and shares the same underlying session. Keep at least one handle alive for the whole program.
+- Close explicitly to flush & release: `session.close().await.unwrap();`
+  (<https://docs.rs/zenoh/latest/zenoh/struct.Session.html#method.close>)
+
+Logging init helper (call once at startup):
+```rust
+zenoh::init_log_from_env_or("error"); // reads RUST_LOG, defaults to "error"
+```
+
+---
+
+## 3. Publisher / Subscriber
+
+### Publisher — `declare_publisher`, `put` with encoding + attachment
+
+Source: examples `z_pub.rs`, `z_pub_thr.rs`.
+
+```rust
+use zenoh::bytes::Encoding;
+
+let publisher = session.declare_publisher("demo/example/topic").await.unwrap();
+
+publisher
+    .put(b"hello".to_vec())          // payload: anything Into<ZBytes>
+    .encoding(Encoding::TEXT_PLAIN)  // optional encoding metadata
+    .attachment(b"meta".to_vec())    // optional attachment (Into<ZBytes>)
+    .await
+    .unwrap();
+
+// Delete (tombstone) on the publisher's key:
+publisher.delete().await.unwrap();
+```
+
+- `Session::declare_publisher(key_expr) -> PublisherBuilder`
+  <https://docs.rs/zenoh/latest/zenoh/struct.Session.html#method.declare_publisher>
+- `Publisher` — <https://docs.rs/zenoh/latest/zenoh/pubsub/struct.Publisher.html>
+- `Publisher::put(payload) -> PublisherPutBuilder` with `.encoding(..)`, `.attachment(..)`,
+  and the QoS knobs in section 8.
+- One-shot publish without a publisher: `session.put(key, payload).await` (`z_put.rs`) and
+  `session.delete(key).await` (`z_delete.rs`).
+
+### Subscriber — stream (`recv_async`) vs callback
+
+**Stream style** (source `z_sub.rs`):
+
+```rust
+let subscriber = session.declare_subscriber("demo/example/**").await.unwrap();
+
+while let Ok(sample) = subscriber.recv_async().await {   // also .recv() for sync
+    let payload = sample.payload().try_to_string()
+        .unwrap_or_else(|e| e.to_string().into());
+    println!("{} on '{}': {}", sample.kind(), sample.key_expr().as_str(), payload);
+
+    if let Some(att) = sample.attachment() {
+        let att = att.try_to_string().unwrap_or_else(|e| e.to_string().into());
+        println!("  attachment: {att}");
+    }
+}
+```
+
+**Callback style** (source `z_sub_thr.rs`): the callback runs on zenoh's I/O thread. Use
+`.background()` so the subscriber keeps running without you holding the handle, or keep the
+returned handle alive.
+
+```rust
+let _subscriber = session
+    .declare_subscriber("demo/example/**")
+    .callback(|sample| {
+        // process sample here; keep it fast & non-blocking
+    })
+    // .callback_mut(move |sample| { ... })  // FnMut variant
+    .background()   // detach: no need to hold the handle
+    .await
+    .unwrap();
+```
+
+`Sample` accessors (docs: <https://docs.rs/zenoh/latest/zenoh/sample/struct.Sample.html>):
+- `sample.payload() -> &ZBytes`
+- `sample.key_expr() -> &KeyExpr` (`.as_str()` for the string)
+- `sample.kind() -> SampleKind` (`Put` / `Delete`)
+- `sample.encoding() -> &Encoding`
+- `sample.attachment() -> Option<&ZBytes>`
+- `sample.timestamp() -> Option<&Timestamp>`
+- `sample.priority()`, `sample.congestion_control()`, `sample.express()`, `sample.reliability()`
+
+`Session::declare_subscriber` — <https://docs.rs/zenoh/latest/zenoh/struct.Session.html#method.declare_subscriber>
+`Subscriber` — <https://docs.rs/zenoh/latest/zenoh/pubsub/struct.Subscriber.html>
+
+---
+
+## 4. Attachments (ZBytes)
+
+Attachments are arbitrary side-band bytes carried next to the payload — ideal for ROS 2 RMW
+metadata (GID, sequence number, source timestamp) that you don't want to bake into the payload.
+
+```rust
+use zenoh::bytes::ZBytes;
+
+// Build an attachment from raw bytes:
+let attachment = ZBytes::from(vec![1u8, 2, 3]);
+
+publisher.put(payload).attachment(attachment).await.unwrap();
+
+// Read it back on the subscriber:
+if let Some(att) = sample.attachment() {           // &ZBytes
+    let raw: std::borrow::Cow<[u8]> = att.to_bytes();  // infallible -> Cow<[u8]>
+    let bytes: &[u8] = &raw;
+    // ... parse your metadata from `bytes`
+}
+```
+
+- On query too: `query.attachment() -> Option<&ZBytes>` and `session.get(sel).attachment(..)`.
+- `ZBytes::to_bytes()` is **infallible** and returns `Cow<[u8]>` (borrow when contiguous, else copy).
+- `ZBytes::try_to_string()` returns `Result<Cow<str>, _>` (fails on non-UTF8).
+
+---
+
+## 5. Key expressions
+
+Types: `zenoh::key_expr::KeyExpr<'a>` (owned/borrowed, validated) and `keyexpr` (unsized
+borrowed str-like). Docs: <https://docs.rs/zenoh/latest/zenoh/key_expr/struct.KeyExpr.html>
+
+```rust
+use zenoh::key_expr::{KeyExpr, keyexpr};
+
+// Validated construction (fails on illegal keys):
+let ke: KeyExpr = KeyExpr::try_from("demo/example/topic").unwrap();
+let ke_static: KeyExpr<'static> = KeyExpr::try_from("a/b".to_string()).unwrap();
+
+// Borrowed, const-checkable:
+let k: &keyexpr = keyexpr::new("test/ping").unwrap();
+
+// Building by concatenation / joining:
+let joined: KeyExpr = ke.join("sub/leaf").unwrap();      // "demo/example/topic/sub/leaf"
+let cat: KeyExpr = (&ke) / keyexpr::new("child").unwrap(); // Div operator also works
+
+// Wildcards:
+//   *   matches a single chunk  (a/*/c  matches a/b/c, not a/b/x/c)
+//   **  matches zero or more chunks (a/**  matches a, a/b, a/b/c ...)
+let wild: KeyExpr = KeyExpr::try_from("demo/example/**").unwrap();
+
+// Matching / inclusion tests:
+let intersects: bool = ke.intersects(&wild);      // do the two sets overlap?
+let includes:   bool = wild.includes(&ke);        // does wild's set contain ke's set?
+```
+
+Most APIs accept `impl TryInto<KeyExpr>`, so you can pass a `&str` literal directly
+(`session.declare_subscriber("a/**")`). Invalid keys surface as an error at declaration time.
+Validation rules: no empty chunks, no leading/trailing `/`, `*`/`**` occupy a whole chunk.
+
+Optionally **declare** a key expression once to get a compact numeric id used on the wire:
+`let ke = session.declare_keyexpr("long/prefix/topic").await.unwrap();`
+(<https://docs.rs/zenoh/latest/zenoh/struct.Session.html#method.declare_keyexpr>) — worthwhile
+for hot ROS topics.
+
+---
+
+## 6. Queryable & Query (request/response = ROS services)
+
+### Server side — declare a queryable and reply
+
+Source: `z_queryable.rs`.
+
+```rust
+let queryable = session
+    .declare_queryable("demo/example/service")
+    .complete(true)   // this queryable fully covers the key expr (affects BestMatching target)
+    .await
+    .unwrap();
+
+while let Ok(query) = queryable.recv_async().await {     // or .callback(...)
+    // Inspect the request:
+    let sel = query.selector();                 // Selector: key_expr + parameters
+    let ke  = query.key_expr();                 // &KeyExpr
+    let params = query.parameters();            // &Parameters (the "?a=b" part)
+    if let Some(req) = query.payload() {         // Option<&ZBytes> request body
+        let body = req.try_to_string().unwrap_or_else(|e| e.to_string().into());
+        // ... decode request
+    }
+    if let Some(att) = query.attachment() {      // Option<&ZBytes> request metadata
+        let _ = att.to_bytes();
+    }
+
+    // Reply with a value (multiple replies allowed; reply on a key matching the query):
+    query
+        .reply("demo/example/service", b"response".to_vec())
+        .await
+        .unwrap();
+
+    // Reply an error instead:
+    // query.reply_err(b"boom".to_vec()).await.unwrap();
+    // Reply a delete:
+    // query.reply_del("demo/example/service").await.unwrap();
+}
+```
+
+- `Session::declare_queryable(key_expr) -> QueryableBuilder`
+  <https://docs.rs/zenoh/latest/zenoh/struct.Session.html#method.declare_queryable>
+- `Query` — <https://docs.rs/zenoh/latest/zenoh/query/struct.Query.html>
+  (`payload()`, `attachment()`, `selector()`, `key_expr()`, `parameters()`, `encoding()`,
+  `reply()`, `reply_err()`, `reply_del()`).
+- `query.reply(key, payload)` also has a builder form with `.encoding(..)`, `.attachment(..)`,
+  `.timestamp(..)`.
+
+### Client side — `session.get(selector)` with payload/attachment, receive replies
+
+Source: `z_get.rs`.
+
+```rust
+use zenoh::query::{QueryTarget, Selector};
+
+let mut builder = session
+    .get("demo/example/service")     // impl TryInto<Selector>; "key?params" also valid
+    .target(QueryTarget::BestMatching) // or ::All / ::AllComplete
+    .timeout(std::time::Duration::from_secs(5))
+    .encoding(zenoh::bytes::Encoding::APPLICATION_JSON)
+    .attachment(b"req-meta".to_vec());
+// Attach a request payload (carry the request body to the queryable):
+builder = builder.payload(b"request-body".to_vec());
+
+let replies = builder.await.unwrap();   // returns a handler channel of Reply
+
+while let Ok(reply) = replies.recv_async().await {
+    match reply.result() {                 // Result<&Sample, &ReplyError>
+        Ok(sample) => {
+            let payload = sample.payload().try_to_string()
+                .unwrap_or_else(|e| e.to_string().into());
+            println!("reply on '{}': {}", sample.key_expr().as_str(), payload);
+        }
+        Err(err) => {
+            let e = err.payload().try_to_string().unwrap_or_else(|e| e.to_string().into());
+            println!("ERROR reply: {e}");
+        }
+    }
+}
+```
+
+- `Session::get(selector) -> SessionGetBuilder` — <https://docs.rs/zenoh/latest/zenoh/struct.Session.html#method.get>
+  Builder methods: `.target(..)`, `.timeout(..)`, `.payload(..)`, `.attachment(..)`,
+  `.encoding(..)`, `.consolidation(..)`, `.with(handler)` (e.g. `RingChannel`).
+- `QueryTarget` — <https://docs.rs/zenoh/latest/zenoh/query/enum.QueryTarget.html>
+  `BestMatching` (one best queryable), `All`, `AllComplete`.
+- `Reply` — <https://docs.rs/zenoh/latest/zenoh/query/struct.Reply.html> — `result()`,
+  `replier_id()`.
+- **Correlating replies to requests:** each `session.get(...)` yields its own `replies`
+  channel, so replies are already scoped to that request — no manual correlation id needed for
+  the basic case. For a ROS-2 service with concurrent in-flight calls you typically run one
+  `get` per call. If you need extra correlation (e.g. matching to a ROS request id), put it in
+  the query **attachment** and echo it back in the reply attachment. The channel closes when
+  the query completes (timeout or all `complete` queryables answered).
+
+---
+
+## 7. Liveliness — this is how discovery works
+
+`session.liveliness()` returns a `Liveliness` handle.
+Docs: <https://docs.rs/zenoh/latest/zenoh/liveliness/struct.Liveliness.html>
+(Requires the **`unstable`** feature.)
+
+Model: an entity **declares a liveliness token** on some key expr. While the token (and its
+session) is alive, that key "exists". Others **subscribe** to a key expr to get `Put` events
+when tokens appear and `Delete` events when they vanish (including on ungraceful disconnect),
+and can **query** to enumerate currently-alive tokens. This is exactly the primitive you build
+ROS 2 discovery on: encode node/topic/type info into token key exprs.
+
+### Declare a token (announce presence)
+
+Source: `z_liveliness.rs`.
+
+```rust
+let token = session
+    .liveliness()
+    .declare_token("group1/node/my_node")
+    .await
+    .unwrap();
+
+// Keep `token` alive for as long as the entity should be considered present.
+// Dropping it (or session close / process crash) emits a Delete to subscribers.
+token.undeclare().await.unwrap();   // explicit graceful removal
+```
+
+`Liveliness::declare_token(key_expr) -> LivelinessTokenBuilder` →
+`LivelinessToken` (<https://docs.rs/zenoh/latest/zenoh/liveliness/struct.LivelinessToken.html>).
+
+### Subscribe to token appear/disappear events
+
+Source: `z_sub_liveliness.rs`.
+
+```rust
+use zenoh::sample::SampleKind;
+
+let subscriber = session
+    .liveliness()
+    .declare_subscriber("group1/**")
+    .history(true)   // also deliver Put events for tokens already alive at subscribe time
+    .await
+    .unwrap();
+
+while let Ok(sample) = subscriber.recv_async().await {
+    match sample.kind() {
+        SampleKind::Put    => println!("NEW  token: {}", sample.key_expr().as_str()),
+        SampleKind::Delete => println!("GONE token: {}", sample.key_expr().as_str()),
+    }
+}
+```
+
+`Liveliness::declare_subscriber(key_expr) -> LivelinessSubscriberBuilder` with `.history(bool)`
+and `.callback(..)` / `.background()` like a normal subscriber. The samples are ordinary
+`Sample`s; only `key_expr()` and `kind()` are meaningful.
+
+### Query currently-alive tokens (enumerate on startup)
+
+Source: `z_get_liveliness.rs`.
+
+```rust
+let replies = session
+    .liveliness()
+    .get("group1/**")
+    .timeout(std::time::Duration::from_secs(10))
+    .await
+    .unwrap();
+
+while let Ok(reply) = replies.recv_async().await {
+    match reply.result() {
+        Ok(sample) => println!("alive: {}", sample.key_expr().as_str()),
+        Err(err)   => println!("error: {:?}", err.payload().to_bytes()),
+    }
+}
+```
+
+`Liveliness::get(key_expr) -> LivelinessGetBuilder` with `.timeout(..)`.
+
+**Discovery pattern:** on startup, `get` the whole discovery keyspace to learn the current
+graph, then keep a `declare_subscriber(..).history(true)` running to receive incremental
+changes. Encode all discovery data in the token key expr (and/or a token attachment, if you
+declare the token with metadata) so a plain liveliness subscriber reconstructs the ROS graph.
+
+---
+
+## 8. QoS-ish knobs & transient-local (durability)
+
+### Per-publisher / per-put QoS
+
+Source: `z_pub_thr.rs`, `z_ping.rs`. Types under `zenoh::qos`.
+
+```rust
+use zenoh::qos::{CongestionControl, Priority, Reliability};
+
+let publisher = session
+    .declare_publisher("demo/topic")
+    .congestion_control(CongestionControl::Block)  // ::Drop (default) | ::Block
+    .priority(Priority::RealTime)                   // 8 levels; ::DEFAULT == Data
+    .express(true)                                  // true = don't batch, lower latency
+    .reliability(Reliability::Reliable)             // ::Reliable | ::BestEffort  (unstable)
+    .await
+    .unwrap();
+
+// The same knobs can be set per-put:
+publisher.put(data)
+    .congestion_control(CongestionControl::Drop)
+    .priority(Priority::InteractiveHigh)
+    .express(false)
+    .await
+    .unwrap();
+```
+
+- `CongestionControl` — <https://docs.rs/zenoh/latest/zenoh/qos/enum.CongestionControl.html>
+  `Drop` (shed messages when queues fill — best-effort-ish) vs `Block` (apply backpressure).
+- `Priority` — <https://docs.rs/zenoh/latest/zenoh/qos/enum.Priority.html>
+  `RealTime`, `InteractiveHigh`, `InteractiveLow`, `DataHigh`, `Data` (`DEFAULT`), `DataLow`,
+  `Background`. Convertible from `u8`.
+- `express(bool)` — bypass batching for latency (at throughput cost).
+- `Reliability` (on subscriber/publisher, **unstable**) — `Reliable` vs `BestEffort`.
+  <https://docs.rs/zenoh/latest/zenoh/qos/enum.Reliability.html>
+
+Map ROS 2 QoS roughly: reliable→`Reliability::Reliable`+`CongestionControl::Block`,
+best-effort→`Reliability::BestEffort`+`CongestionControl::Drop`.
+
+### Transient-local / durability → `zenoh-ext` Advanced pub/sub
+
+Zenoh's core pub/sub is *volatile* (a late subscriber misses prior samples). ROS 2
+`TRANSIENT_LOCAL` (and history depth) is provided by **`zenoh-ext`**, which in 1.x is the
+`AdvancedPublisher` / `AdvancedSubscriber` API (it supersedes the older
+`PublicationCache` / `QueryingSubscriber` names from earlier 1.x; those types may still exist
+but the advanced builders are the recommended surface).
+
+**Publisher side** (caches samples so late/recovering subscribers can fetch them). Source
+`zenoh-ext/examples/examples/z_advanced_pub.rs`. **Requires `timestamping/enabled = true`** in
+config.
+
+```rust
+use std::time::Duration;
+use zenoh_ext::{AdvancedPublisherBuilderExt, CacheConfig, MissDetectionConfig};
+
+let publisher = session
+    .declare_publisher("demo/example/topic")
+    .cache(CacheConfig::default().max_samples(10))   // keep last N (history depth)
+    .sample_miss_detection(
+        MissDetectionConfig::default().heartbeat(Duration::from_millis(500)))
+    .publisher_detection()   // announce this publisher via liveliness (discoverable)
+    .await
+    .unwrap();
+
+publisher.put(b"data".to_vec()).await.unwrap();
+```
+
+**Subscriber side** (queries history on join, recovers missed samples). Source
+`z_advanced_sub.rs`.
+
+```rust
+use zenoh_ext::{AdvancedSubscriberBuilderExt, HistoryConfig, RecoveryConfig};
+
+let subscriber = session
+    .declare_subscriber("demo/example/**")
+    .history(HistoryConfig::default().detect_late_publishers()) // pull cached history -> transient_local
+    .recovery(RecoveryConfig::default().heartbeat())            // recover missed samples
+    .subscriber_detection()                                     // discoverable via liveliness
+    .await
+    .unwrap();
+
+// Optional: get notified of detected gaps
+let miss_listener = subscriber.sample_miss_listener().await.unwrap();
+
+loop {
+    tokio::select! {
+        s = subscriber.recv_async() => if let Ok(sample) = s { /* ... */ },
+        m = miss_listener.recv_async() => if let Ok(miss) = m {
+            println!("missed {} from {:?}", miss.nb(), miss.source());
+        },
+    }
+}
+```
+
+- Crate: `zenoh-ext` (features `["unstable"]`). Docs: <https://docs.rs/zenoh-ext/latest/zenoh_ext/>
+- The `AdvancedPublisherBuilderExt` / `AdvancedSubscriberBuilderExt` traits add `.cache()`,
+  `.sample_miss_detection()`, `.publisher_detection()` (pub) and `.history()`, `.recovery()`,
+  `.subscriber_detection()` (sub) onto the *normal* `declare_publisher` / `declare_subscriber`
+  builders — bring the trait into scope with `use zenoh_ext::...`.
+- `zenoh-ext` also provides `z_serialize` / `z_deserialize` for typed ZBytes (numbers, Vec,
+  HashMap, tuples) — see section 9.
+
+---
+
+## 9. Encoding & ZBytes
+
+### Encoding
+
+`zenoh::bytes::Encoding` — metadata hint, not enforced. Docs:
+<https://docs.rs/zenoh/latest/zenoh/bytes/struct.Encoding.html>
+
+```rust
+use zenoh::bytes::Encoding;
+Encoding::ZENOH_BYTES;         // default, raw bytes
+Encoding::ZENOH_STRING;        // utf-8 string
+Encoding::TEXT_PLAIN;
+Encoding::APPLICATION_JSON;
+Encoding::APPLICATION_CBOR;
+Encoding::APPLICATION_PROTOBUF;
+Encoding::APPLICATION_OCTET_STREAM;
+// Custom / with schema suffix:
+let enc: Encoding = Encoding::from("application/ros2msg");
+let enc2 = Encoding::APPLICATION_PROTOBUF.with_schema("my.Type");
+```
+
+### ZBytes construction and back to bytes
+
+Type `zenoh::bytes::ZBytes`. Source `z_bytes.rs`. Docs:
+<https://docs.rs/zenoh/latest/zenoh/bytes/struct.ZBytes.html>
+
+```rust
+use zenoh::bytes::ZBytes;
+
+// From &[u8]  -> copies:
+let a = ZBytes::from(b"raw bytes".as_slice());
+// From Vec<u8> -> moves (no copy):
+let b = ZBytes::from(vec![1u8, 2, 3]);
+// From &str / String:
+let c = ZBytes::from("text");
+let d = ZBytes::from("text".to_string());
+// From an iterator of u8:
+let e: ZBytes = (0..256u32).map(|i| (i % 10) as u8).collect::<Vec<u8>>().into();
+
+// Back to bytes (infallible, borrows when contiguous):
+let raw: std::borrow::Cow<[u8]> = b.to_bytes();
+let owned: Vec<u8> = b.to_bytes().into_owned();     // force a Vec<u8>
+// Back to string (fallible):
+let s: std::borrow::Cow<str> = c.try_to_string().unwrap();
+
+// Streaming writer / reader for zero-ish-copy assembly:
+use std::io::{Read, Write};
+let mut w = ZBytes::writer();
+w.write_all(&[0u8, 1]).unwrap();
+w.append(ZBytes::from([2, 3]));
+let zb = w.finish();                 // ZBytes == [0,1,2,3]
+let mut r = zb.reader();
+let mut buf = [0u8; 2];
+r.read_exact(&mut buf).unwrap();
+```
+
+Typed serialization via `zenoh-ext` (length-prefixed, self-describing for the supported set):
+
+```rust
+use zenoh_ext::{z_serialize, z_deserialize};
+let payload: ZBytes = z_serialize(&1234u32);
+let n: u32 = z_deserialize(&payload).unwrap();
+// also Vec<T>, HashMap<K,V>, tuples, arrays, and primitive numerics.
+```
+
+For ROS 2 you'll typically ship the **CDR-serialized message** as a raw `Vec<u8>` payload
+(`ZBytes::from(cdr_vec)`) and set an appropriate `Encoding`, rather than using `z_serialize`.
+
+---
+
+## 10. Gotchas
+
+1. **Runtime.** Zenoh runs its own internal tokio runtime for I/O, but the *async* API
+   (`.await`) must be driven by *your* runtime — wrap `main` in `#[tokio::main]` or build a
+   runtime. The blocking `.wait()` API (trait `zenoh::Wait`) works anywhere but can deadlock if
+   called from *inside* a tokio worker; prefer `.await` when already async.
+
+2. **Keep the `Session` alive.** `Session` is `Clone` (cheap `Arc`). If the last handle drops,
+   the session closes and all its publishers/subscribers/queryables/tokens stop. Store it in
+   your RMW context struct for the whole process lifetime. Call `session.close().await` on
+   shutdown to flush.
+
+3. **Declarations must be stored — or explicitly backgrounded.** `declare_publisher`,
+   `declare_subscriber`, `declare_queryable`, and `declare_token` return handles whose `Drop`
+   **undeclares** them. If you write `let _ = session.declare_subscriber(...)...;` it is dropped
+   immediately and receives nothing. Either bind it to a named variable you keep, or call
+   `.background()` on the builder to detach its lifetime from the handle. Same for
+   `LivelinessToken`: dropping the token removes it (emits `Delete`).
+
+4. **Undeclaring.** Prefer explicit `token.undeclare().await` / `subscriber.undeclare().await`
+   for deterministic, graceful teardown (and to control ordering of `Delete` events) rather
+   than relying on `Drop`, which runs synchronously and can't be `.await`ed.
+
+5. **Callbacks run on zenoh threads.** A `.callback(..)` closure executes on zenoh's internal
+   I/O thread. Keep it fast and non-blocking; do not block or call `.wait()` inside it. Offload
+   heavy work to a channel. The stream (`recv_async`) style runs on *your* task instead.
+
+6. **Volatile by default.** Plain pub/sub does not retain history; a subscriber that joins
+   after a `put` misses it. Use `zenoh-ext` Advanced pub/sub (section 8) for
+   transient-local/history, and enable `timestamping/enabled = true` in config (the cache needs
+   timestamps).
+
+7. **`unstable` feature.** Liveliness, matching listeners, `Reliability` selection, and the
+   `zenoh-ext` advanced APIs are gated behind `features = ["unstable"]` on both `zenoh` and
+   `zenoh-ext`. Missing it produces confusing "method not found" errors.
+
+8. **KeyExpr validation is at declaration/parse time.** Passing a `&str` builds and validates a
+   `KeyExpr` lazily; malformed keys (empty chunks, leading/trailing `/`, `*` not filling a
+   chunk) fail there, not at compile time. Validate untrusted topic strings up front.
+
+9. **Wildcard subtlety:** `*` is exactly one chunk, `**` is zero-or-more. `a/**` matches `a`
+   itself. Use `intersects()` (overlap) vs `includes()` (superset) deliberately when routing.
+
+10. **Reply key must match the query.** In a queryable, `query.reply(key, ..)` must use a key
+    expression that the original query's selector matches, or the reply is dropped. Reusing the
+    queryable's own key expr (as in `z_queryable.rs`) is the safe default.
+
+---
+
+## Quick source index
+
+| Concern | Example file | Doc |
+|---|---|---|
+| Publish | `examples/examples/z_pub.rs`, `z_put.rs` | [Publisher](https://docs.rs/zenoh/latest/zenoh/pubsub/struct.Publisher.html) |
+| Subscribe | `z_sub.rs`, `z_sub_thr.rs`, `z_pull.rs` | [Subscriber](https://docs.rs/zenoh/latest/zenoh/pubsub/struct.Subscriber.html) |
+| Query client | `z_get.rs` | [Session::get](https://docs.rs/zenoh/latest/zenoh/struct.Session.html#method.get) |
+| Queryable server | `z_queryable.rs` | [Query](https://docs.rs/zenoh/latest/zenoh/query/struct.Query.html) |
+| Liveliness token | `z_liveliness.rs` | [Liveliness](https://docs.rs/zenoh/latest/zenoh/liveliness/struct.Liveliness.html) |
+| Liveliness sub | `z_sub_liveliness.rs` | " |
+| Liveliness get | `z_get_liveliness.rs` | " |
+| QoS knobs | `z_pub_thr.rs`, `z_ping.rs` | [qos](https://docs.rs/zenoh/latest/zenoh/qos/index.html) |
+| ZBytes/Encoding | `z_bytes.rs` | [bytes](https://docs.rs/zenoh/latest/zenoh/bytes/index.html) |
+| Advanced pub/sub | `zenoh-ext/examples/examples/z_advanced_pub.rs`, `z_advanced_sub.rs` | [zenoh_ext](https://docs.rs/zenoh-ext/latest/zenoh_ext/) |
+| Config helper | `examples/src/lib.rs` (`CommonArgs`) | [Config](https://docs.rs/zenoh/latest/zenoh/config/struct.Config.html) |

--- a/docs/zenoh_study/test_plan.md
+++ b/docs/zenoh_study/test_plan.md
@@ -1,0 +1,124 @@
+# Test plan
+
+Goal: a **lean** but meaningful test suite that (1) keeps the existing DDS
+behaviour green and (2) proves each Zenoh feature interoperates with real ROS 2
+over `rmw_zenoh`. Total CI budget target: **< 30 min**. Sources of use cases:
+[`research/workshop_use_cases.md`](research/workshop_use_cases.md) and the basic
+ROS 2 CLI the user called out.
+
+## 1. What exists today
+
+**Tests** (pure Rust, `ros2-client`↔`ros2-client`, RustDDS multicast in-process):
+- `tests/pub_and_sub.rs` — two nodes, `std_msgs/String` on a topic, 5 s timeout.
+- `tests/late_joiner.rs` — transient-local + reliable, late subscriber gets
+  buffered history.
+- Unit tests inside `src/` (`names.rs`, `context.rs` node-create).
+
+**CI** (`.github/workflows/`):
+- `static-checks.yml` — `fmt` (nightly), `doc`, `clippy` (nightly, all
+  lib/bins/examples), `msrv` (`cargo check` on 1.85.1).
+- `tests.yml` — `cargo test --test-threads=1` and `--features=security`, Ubuntu.
+- `tests-macos.yml` — `cargo test` on macOS.
+- `audit.yml` — `cargo audit` on `Cargo.*` changes.
+
+**Gaps:** no Zenoh build coverage; no interop against real ROS 2; no unit tests
+for wire formats (keyexpr/QoS/attachment/gid/type-hash); no service/action/param
+integration tests even for DDS.
+
+## 2. Design: three test tiers
+
+### Tier A — Unit tests (no network, run everywhere, milliseconds)
+Deterministic wire-format tests that pin our bytes/strings to `rmw_zenoh`'s
+(from [`research/rmw_zenoh.md`](research/rmw_zenoh.md)). These catch interop
+regressions without needing ROS or a router.
+
+| ID | Asserts | Feature |
+|----|---------|---------|
+| A1 | data keyexpr `0/chatter/std_msgs::msg::dds_::String_/RIHS01_…` | E2 |
+| A2 | liveliness keyexpr for NN/MP/MS/SS/SC incl. `%` mangling | E2 |
+| A3 | compact QoS encode/decode round-trip; `::,7:,:,:,,` for depth 7; `depth==0`→42 | E1/E2 |
+| A4 | attachment byte layout `(i64 seq, i64 ts, 1-byte len 16, 16-byte gid)` via `z_serialize` | E2 |
+| A5 | GID = XXH3-128(liveliness key), low64‖high64 LE, vs a known vector | E2 |
+| A6 | type-hash table lookups; wildcard-hash key for receivers | E2 |
+| A7 | CDR round-trip of `std_msgs/String`, a struct, `AddTwoInts` req/resp; 4-byte encapsulation header present exactly once | E2/E4 |
+| A8 | `QosProfile` ↔ `rustdds::QosPolicies` conversions (dds build) | E1 |
+| A9 | existing `names.rs` tests keep passing | — |
+
+### Tier B — In-process integration (`ros2-client`↔`ros2-client` over Zenoh, no ROS)
+Two contexts in one test process, **connected directly** (peer A listens on
+`tcp/localhost:<port>`, peer B connects) so **no `zenohd` router is required** —
+keeps these hermetic and fast. Mirrors the existing DDS tests.
+
+| ID | Scenario | Feature |
+|----|----------|---------|
+| B1 | pub/sub `std_msgs/String`, volatile (port of `pub_and_sub.rs`) | E4 |
+| B2 | transient-local late joiner gets history (port of `late_joiner.rs`) | E4 |
+| B3 | graph: subscriber node sees publisher via graph cache; `wait_for_subscription` resolves | E5 |
+| B4 | service `AddTwoInts` request/response, assert `sum` | E6 |
+| B5 | action `Fibonacci`: goal → feedback → result sequence | E7 |
+| B6 | parameters: set/get/list round-trip via the param services | E8 |
+
+These also run under the **`dds`** feature (same source, cfg-gated harness) so we
+don't lose DDS coverage — B1/B2 already exist as DDS tests.
+
+### Tier C — Interop with real ROS 2 (`rmw_zenoh`), the definition of done
+One CI job on a `ros:jazzy` container with `rmw_zenoh_cpp`, `demo_nodes_cpp`,
+`example_interfaces`, `action_tutorials_*` installed, a `rmw_zenohd` router
+running, and Rust to build our examples. `RMW_IMPLEMENTATION=rmw_zenoh_cpp` on
+the ROS side. Each case is a small script asserting on output; a
+[`ros2-client`] node is one side, a ROS 2 CLI/demo node the other.
+
+| ID | Scenario | Direction | Feature |
+|----|----------|-----------|---------|
+| C1 | `ros2-client` talker → `ros2 topic echo /chatter` sees the string | pub→ROS | E4 |
+| C2 | `ros2 topic pub /chatter std_msgs/String` → `ros2-client` listener prints it | ROS→sub | E4 |
+| C3 | `ros2 topic list` / `ros2 node list` show the `ros2-client` entity | graph | E5 |
+| C4 | `ros2 service call /add_two_ints …` → `ros2-client` server replies `sum` | ROS→srv | E6 |
+| C5 | `ros2-client` client → C++ `add_two_ints_server`, assert `sum` | client→ROS | E6 |
+| C6 | `ros2 action send_goal /fibonacci … --feedback` → `ros2-client` server | ROS→action | E7 |
+| C7 | `ros2-client` action client → C++ `fibonacci_action_server` | client→ROS | E7 |
+| C8 | `ros2 param set/get` on a `ros2-client` node | params | E8 |
+| C9 | `ros2 topic echo /rosout` shows a `ros2-client` log line | rosout | E9 |
+
+C1–C4/C8/C9 are the lean core; C5/C6/C7 add the reverse direction. If CI time is
+tight, C5/C7 (reverse service/action) may be marked `slow` and run on a nightly
+schedule rather than per-PR — but the aim is to keep all of C in the < 30 min
+per-PR budget.
+
+## 3. CI changes
+
+Add one workflow `tests-zenoh.yml` (per-PR):
+
+1. **Job `build-zenoh`** (fast, always): `cargo check/clippy/doc/test
+   --no-default-features --features zenoh` — compiles the Zenoh backend and runs
+   **Tier A** unit tests. Also `cargo check --no-default-features --features dds`
+   to guard the exclusivity. (~5–8 min)
+2. **Job `integration-zenoh`** (fast, always): run **Tier B** in-process tests
+   (`cargo test --no-default-features --features zenoh -- --test-threads=1`).
+   No router needed (direct peer connection). (~3–5 min)
+3. **Job `interop-ros2`** (`container: ros:jazzy`): install
+   `ros-jazzy-rmw-zenoh-cpp ros-jazzy-demo-nodes-cpp
+   ros-jazzy-example-interfaces ros-jazzy-action-tutorials-cpp` + rustup; start
+   `rmw_zenohd`; run the **Tier C** scripts under `RMW_IMPLEMENTATION=
+   rmw_zenoh_cpp`. Cache cargo + apt. (~12–18 min)
+
+Keep existing `tests.yml`/`static-checks.yml` for the **`dds`** default so DDS
+never regresses. `static-checks` gains a `--features zenoh` clippy/doc pass.
+
+Budget: A+B jobs ≈ 10 min, C job ≈ 15 min, run in parallel → wall-clock well
+under 30 min. `msrv`/`audit`/`macos` unaffected.
+
+## 4. Harness notes
+
+- Tier C scripts live in `interop/zenoh/` (shell + tiny Rust example binaries),
+  invoked by the workflow; each has a hard timeout and asserts on captured
+  stdout, following the pattern of the workshop ex-1 commands.
+- In-process Tier B uses explicit connect/listen endpoints to avoid multicast
+  flakiness and the router dependency.
+- Every new feature PR (E4–E9) must land with its Tier A/B tests and wire its
+  Tier C case, so CI coverage grows with the implementation rather than at the
+  end.
+- Local dev (this repo's environment currently has **no** ROS/zenohd): install a
+  real ROS 2 + `rmw_zenoh` via `pixi`/RoboStack or the `ros:jazzy` Docker image
+  when running Tier C locally; Tiers A/B need only the Rust toolchain and (for B)
+  no external services.

--- a/examples/zenoh_demo/main.rs
+++ b/examples/zenoh_demo/main.rs
@@ -1,0 +1,110 @@
+//! Self-contained demo of the **Zenoh** backend of `ros2-client`.
+//!
+//! Build & run with the `zenoh` backend (the `dds` default off):
+//!
+//! ```console
+//! cargo run --no-default-features --features zenoh --example zenoh_demo
+//! ```
+//!
+//! It starts a talker and a listener in one process, connected directly over
+//! IPv4 loopback (Zenoh *peer* mode, multicast disabled, explicit endpoints),
+//! so it works without a running Zenoh router. In a real multi-process or
+//! multi-host deployment you would instead run a Zenoh router (`zenohd`) — as
+//! `rmw_zenoh` does — or configure peer `connect`/`listen` endpoints; see
+//! `docs/decisions/0009-zenoh-router-and-config.md`.
+//!
+//! The listener also reads `/rosout`, and the talker logs there, to show
+//! logging on the Zenoh backend.
+
+use std::time::{Duration, Instant};
+
+use ros2_client::{
+  ros2::LogLevel, rosout, Context, ContextOptions, MessageTypeName, Name, NodeName, NodeOptions,
+  QosProfile,
+};
+use zenoh::Config;
+
+/// A peer config on IPv4 loopback with multicast off. Pinning `listen` and
+/// (optionally) `connect` ports lets two in-process peers connect directly, no
+/// router required.
+fn loopback_config(listen_port: u16, connect_port: Option<u16>) -> Config {
+  let mut c = Config::default();
+  c.insert_json5("mode", "\"peer\"").unwrap();
+  c.insert_json5("scouting/multicast/enabled", "false")
+    .unwrap();
+  c.insert_json5(
+    "listen/endpoints",
+    &format!("[\"tcp/127.0.0.1:{listen_port}\"]"),
+  )
+  .unwrap();
+  if let Some(p) = connect_port {
+    c.insert_json5("connect/endpoints", &format!("[\"tcp/127.0.0.1:{p}\"]"))
+      .unwrap();
+  }
+  c
+}
+
+fn main() {
+  let talker_port = 17600;
+  let listener_port = 17601;
+
+  // Two independent ROS contexts (each wraps its own Zenoh session).
+  let talker_ctx =
+    Context::with_options(ContextOptions::new().zenoh_config(loopback_config(talker_port, None)))
+      .expect("open talker context");
+  let listener_ctx = Context::with_options(
+    ContextOptions::new().zenoh_config(loopback_config(listener_port, Some(talker_port))),
+  )
+  .expect("open listener context");
+
+  let talker = talker_ctx.new_node(NodeName::new("/", "talker").unwrap(), NodeOptions::new());
+  let listener = listener_ctx.new_node(NodeName::new("/", "listener").unwrap(), NodeOptions::new());
+
+  // A `/chatter` topic carrying `std_msgs/String`.
+  let chatter = |node: &ros2_client::Node| {
+    node.create_topic(
+      &Name::new("/", "chatter").unwrap(),
+      MessageTypeName::new("std_msgs", "String"),
+      &QosProfile::default(),
+    )
+  };
+  let publisher = talker
+    .create_publisher::<String>(&chatter(&talker), None)
+    .expect("create publisher");
+  let subscription = listener
+    .create_subscription::<String>(&chatter(&listener), None)
+    .expect("create subscription");
+
+  // rosout: the talker logs, the listener reads `/rosout`.
+  let logger = talker.create_logger().expect("create logger");
+  let rosout_reader = listener.read_rosout().expect("read rosout");
+
+  println!("Publishing on /chatter (Zenoh backend). Ctrl-C to stop.");
+
+  let mut count = 0;
+  let mut received = 0;
+  let deadline = Instant::now() + Duration::from_secs(10);
+  while Instant::now() < deadline {
+    count += 1;
+    let msg = format!("Hello ROS 2 over Zenoh #{count}");
+    publisher.publish(msg.clone()).expect("publish");
+    rosout!(logger, LogLevel::Info, "published: {msg}");
+
+    // Drain whatever has arrived.
+    while let Ok(Some((data, info))) = subscription.try_take() {
+      received += 1;
+      println!(
+        "chatter: {data:?}  (seq {}, gid {:02x?}…)",
+        info.sequence_number(),
+        &info.source_gid()[..4]
+      );
+    }
+    while let Ok(Some((log, _))) = rosout_reader.try_take() {
+      println!("/rosout [{}] {}: {}", log.level, log.name, log.msg);
+    }
+
+    std::thread::sleep(Duration::from_millis(500));
+  }
+
+  println!("Done: sent {count} messages, received {received} on /chatter.");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,8 @@
 
 // ---------------------------------------------------------------------------
 // Middleware backend selection. Exactly one of `dds` (default) or `zenoh` must
-// be enabled. See docs/decisions/0002-dual-backend-compile-time-feature-selection.md
+// be enabled. See
+// docs/decisions/0002-dual-backend-compile-time-feature-selection.md
 // ---------------------------------------------------------------------------
 #[cfg(all(feature = "dds", feature = "zenoh"))]
 compile_error!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,8 +225,8 @@ pub mod ros2 {
   pub use crate::log::LogLevel;
   // TODO: What to do about SecurityError (exists based on feature "security")
   pub use crate::names::Name; // import Name as ros2::Name if there is clash
-                              // otherwise
-                              // Backend-neutral QoS (available on both backends).
+  // otherwise
+  // Backend-neutral QoS (available on both backends).
   pub use crate::qos::QosProfile;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,9 @@ pub use zenoh_backend::pubsub::{MessageInfo, Publisher, Subscription};
 #[cfg(feature = "zenoh")]
 #[doc(inline)]
 pub use zenoh_backend::service::{Client, RmwRequestId, Server};
+#[cfg(feature = "zenoh")]
+#[doc(inline)]
+pub use zenoh_backend::action::{ActionClient, ActionServer, GoalId};
 
 /// Module for stuff we do not want to export from top level;
 pub mod ros2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,12 @@ pub use rosout::{NodeLoggingHandle, RosoutRaw};
 #[cfg(feature = "zenoh")]
 #[doc(inline)]
 pub use zenoh_backend::context::{Context, ContextOptions};
+#[cfg(feature = "zenoh")]
+#[doc(inline)]
+pub use zenoh_backend::node::{Node, NodeOptions, Topic};
+#[cfg(feature = "zenoh")]
+#[doc(inline)]
+pub use zenoh_backend::pubsub::{MessageInfo, Publisher, Subscription};
 
 /// Module for stuff we do not want to export from top level;
 pub mod ros2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,8 +225,8 @@ pub mod ros2 {
   pub use crate::log::LogLevel;
   // TODO: What to do about SecurityError (exists based on feature "security")
   pub use crate::names::Name; // import Name as ros2::Name if there is clash
-  // otherwise
-  // Backend-neutral QoS (available on both backends).
+                              // otherwise
+                              // Backend-neutral QoS (available on both backends).
   pub use crate::qos::QosProfile;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,12 @@
 //!   // --> smol::block_on( subscription_stream );
 //! ```
 
+// During the incremental Zenoh port, several backend-neutral helpers (name
+// mangling, time, etc.) are currently only consumed by the DDS backend; they
+// become live as E4–E6 wire up the Zenoh side. Allow dead_code on the `zenoh`
+// build so it stays warning-clean without scattering per-item cfgs.
+#![cfg_attr(not(feature = "dds"), allow(dead_code))]
+
 // ---------------------------------------------------------------------------
 // Middleware backend selection. Exactly one of `dds` (default) or `zenoh` must
 // be enabled. See
@@ -64,11 +70,19 @@ compile_error!(
    or `--features zenoh`."
 );
 
+// lazy_static is only used by DDS-backend modules (builtin_topics, context).
+#[cfg(feature = "dds")]
 #[macro_use]
 extern crate lazy_static;
 
+// NOTE: modules that depend on RustDDS are gated behind the `dds` feature.
+// The `zenoh` backend re-implements the corresponding public API incrementally
+// (see docs/zenoh_study/refactoring_plan.md, issues E3–E9). Backend-neutral
+// modules (names, message, qos, time, the wire-format spec) compile on both.
+
 /// Some builtin datatypes needed for ROS2 communication
 /// Some convenience topic infos for ROS2 communication
+#[cfg(feature = "dds")]
 pub mod builtin_topics;
 
 #[doc(hidden)]
@@ -78,6 +92,7 @@ pub mod action_msgs; // action mechanism implementation
 pub mod builtin_interfaces;
 
 #[doc(hidden)]
+#[cfg(feature = "dds")]
 pub mod context;
 
 #[doc(hidden)] // needed for actions implementation
@@ -85,32 +100,43 @@ pub mod unique_identifier_msgs;
 
 #[doc(hidden)]
 #[deprecated] // we should remove the rest of these
+#[cfg(feature = "dds")]
 pub mod interfaces;
 
 /// ROS 2 Action machinery
+#[cfg(feature = "dds")]
 pub mod action;
 /// ROS 2 distribution identification (compile-time selection + runtime check)
 pub mod distributions;
+#[cfg(feature = "dds")]
 pub mod entities_info;
+#[cfg(feature = "dds")]
 mod gid;
 pub mod log;
 pub mod message;
+#[cfg(feature = "dds")]
 pub mod message_info;
 pub mod names;
+#[cfg(feature = "dds")]
 pub mod parameters;
 #[doc(hidden)]
+#[cfg(feature = "dds")]
 pub mod pubsub;
 /// Backend-neutral Quality-of-Service profile.
 pub mod qos;
+#[cfg(feature = "dds")]
 pub mod rcl_interfaces;
 pub mod ros_time;
+#[cfg(feature = "dds")]
 pub mod rosout;
+#[cfg(feature = "dds")]
 pub mod service;
 
 pub mod steady_time;
 mod wide_string;
 
 #[doc(hidden)]
+#[cfg(feature = "dds")]
 pub(crate) mod node;
 
 /// Zenoh middleware backend (cargo feature `zenoh`).
@@ -122,6 +148,7 @@ pub(crate) mod node;
 pub(crate) mod zenoh_backend;
 
 // Re-exports from crate root to simplify usage
+#[cfg(feature = "dds")]
 #[doc(inline)]
 pub use context::*;
 #[doc(inline)]
@@ -130,26 +157,37 @@ pub use distributions::{RosDistro, COMPILED_ROS_DISTRO};
 pub use message::Message;
 #[doc(inline)]
 pub use names::{ActionTypeName, MessageTypeName, Name, NodeName, ServiceTypeName};
+#[cfg(feature = "dds")]
 #[doc(inline)]
 pub use message_info::MessageInfo;
+#[cfg(feature = "dds")]
 #[doc(inline)]
 pub use node::*;
+#[cfg(feature = "dds")]
 #[doc(inline)]
 pub use parameters::{Parameter, ParameterValue};
 #[doc(inline)]
 pub use qos::QosProfile;
+#[cfg(feature = "dds")]
 #[doc(inline)]
 pub use pubsub::*;
+#[cfg(feature = "dds")]
 #[doc(inline)]
 pub use service::{AService, Client, Server, Service, ServiceMapping};
+#[cfg(feature = "dds")]
 #[doc(inline)]
 pub use action::{Action, ActionTypes};
 #[doc(inline)]
 pub use wide_string::WString;
 #[doc(inline)]
 pub use ros_time::{ROSTime, SystemTime};
+#[cfg(feature = "dds")]
 #[doc(inline)]
 pub use rosout::{NodeLoggingHandle, RosoutRaw};
+// Zenoh backend public API (incremental; see E3–E9).
+#[cfg(feature = "zenoh")]
+#[doc(inline)]
+pub use zenoh_backend::context::{Context, ContextOptions};
 
 /// Module for stuff we do not want to export from top level;
 pub mod ros2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,11 @@ mod wide_string;
 pub(crate) mod node;
 
 /// Zenoh middleware backend (cargo feature `zenoh`).
-#[cfg(feature = "zenoh")]
+///
+/// The module is compiled unconditionally so its backend-neutral "wire-format
+/// spec" submodules (key expressions, type hashes, GID) can be unit-tested on
+/// any build. Submodules that depend on the `zenoh` crate are gated behind
+/// `#[cfg(feature = "zenoh")]` inside the module.
 pub(crate) mod zenoh_backend;
 
 // Re-exports from crate root to simplify usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,8 @@ pub mod names;
 pub mod parameters;
 #[doc(hidden)]
 pub mod pubsub;
+/// Backend-neutral Quality-of-Service profile.
+pub mod qos;
 pub mod rcl_interfaces;
 pub mod ros_time;
 pub mod rosout;
@@ -135,6 +137,8 @@ pub use node::*;
 #[doc(inline)]
 pub use parameters::{Parameter, ParameterValue};
 #[doc(inline)]
+pub use qos::QosProfile;
+#[doc(inline)]
 pub use pubsub::*;
 #[doc(inline)]
 pub use service::{AService, Client, Server, Service, ServiceMapping};
@@ -160,7 +164,9 @@ pub mod ros2 {
   pub use crate::log::LogLevel;
   // TODO: What to do about SecurityError (exists based on feature "security")
   pub use crate::names::Name; // import Name as ros2::Name if there is clash
-                              // otherwise
+  // otherwise
+  // Backend-neutral QoS (available on both backends).
+  pub use crate::qos::QosProfile;
 }
 
 /// Re-export of the entire RustDDS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,12 @@ pub use zenoh_backend::parameters::{ParameterClient, ParameterEvent, ParameterSe
 #[cfg(feature = "zenoh")]
 #[doc(inline)]
 pub use zenoh_backend::rosout::{Log, Logger};
+#[cfg(feature = "zenoh")]
+#[doc(inline)]
+pub use zenoh_backend::{
+  graph_cache::{GraphEntity, GraphEvent},
+  keyexpr::EntityKind,
+};
 
 /// Module for stuff we do not want to export from top level;
 pub mod ros2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,9 @@ pub use zenoh_backend::node::{Node, NodeOptions, Topic};
 #[cfg(feature = "zenoh")]
 #[doc(inline)]
 pub use zenoh_backend::pubsub::{MessageInfo, Publisher, Subscription};
+#[cfg(feature = "zenoh")]
+#[doc(inline)]
+pub use zenoh_backend::service::{Client, RmwRequestId, Server};
 
 /// Module for stuff we do not want to export from top level;
 pub mod ros2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,9 @@ pub use zenoh_backend::action::{ActionClient, ActionServer, GoalId};
 #[cfg(feature = "zenoh")]
 #[doc(inline)]
 pub use zenoh_backend::parameters::{ParameterClient, ParameterEvent, ParameterServer};
+#[cfg(feature = "zenoh")]
+#[doc(inline)]
+pub use zenoh_backend::rosout::{Log, Logger};
 
 /// Module for stuff we do not want to export from top level;
 pub mod ros2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,22 @@
 //!   // --> smol::block_on( subscription_stream );
 //! ```
 
+// ---------------------------------------------------------------------------
+// Middleware backend selection. Exactly one of `dds` (default) or `zenoh` must
+// be enabled. See docs/decisions/0002-dual-backend-compile-time-feature-selection.md
+// ---------------------------------------------------------------------------
+#[cfg(all(feature = "dds", feature = "zenoh"))]
+compile_error!(
+  "features `dds` and `zenoh` are mutually exclusive: enable exactly one. \
+   To use the Zenoh backend, build with `--no-default-features --features zenoh`."
+);
+#[cfg(not(any(feature = "dds", feature = "zenoh")))]
+compile_error!(
+  "no middleware backend selected: enable exactly one of `dds` (default) or \
+   `zenoh`. You likely used `--no-default-features` without `--features dds` \
+   or `--features zenoh`."
+);
+
 #[macro_use]
 extern crate lazy_static;
 
@@ -94,6 +110,10 @@ mod wide_string;
 #[doc(hidden)]
 pub(crate) mod node;
 
+/// Zenoh middleware backend (cargo feature `zenoh`).
+#[cfg(feature = "zenoh")]
+pub(crate) mod zenoh_backend;
+
 // Re-exports from crate root to simplify usage
 #[doc(inline)]
 pub use context::*;
@@ -124,8 +144,12 @@ pub use rosout::{NodeLoggingHandle, RosoutRaw};
 
 /// Module for stuff we do not want to export from top level;
 pub mod ros2 {
+  // RustDDS-derived re-exports are only available on the `dds` backend.
+  // The `zenoh` backend provides owned equivalents (see issue E1 / ADR-0004).
+  #[cfg(feature = "dds")]
   pub use rustdds::{qos::policy, Duration, QosPolicies, QosPolicyBuilder, Timestamp};
   //TODO: re-export RustDDS error types until ros2-client defines its own
+  #[cfg(feature = "dds")]
   pub use rustdds::dds::{CreateError, ReadError, WaitError, WriteError};
 
   pub use crate::log::LogLevel;
@@ -136,4 +160,7 @@ pub mod ros2 {
 
 /// Re-export of the entire RustDDS,
 /// to provide access to the same version that ros2-client uses.
+///
+/// Only available on the `dds` backend.
+#[cfg(feature = "dds")]
 pub use rustdds;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,14 +117,14 @@ pub mod message;
 #[cfg(feature = "dds")]
 pub mod message_info;
 pub mod names;
-#[cfg(feature = "dds")]
+/// Rust-like representation of ROS 2 Parameters (backend-neutral).
 pub mod parameters;
 #[doc(hidden)]
 #[cfg(feature = "dds")]
 pub mod pubsub;
 /// Backend-neutral Quality-of-Service profile.
 pub mod qos;
-#[cfg(feature = "dds")]
+/// `rcl_interfaces` message/service payload types (backend-neutral).
 pub mod rcl_interfaces;
 pub mod ros_time;
 #[cfg(feature = "dds")]
@@ -163,7 +163,6 @@ pub use message_info::MessageInfo;
 #[cfg(feature = "dds")]
 #[doc(inline)]
 pub use node::*;
-#[cfg(feature = "dds")]
 #[doc(inline)]
 pub use parameters::{Parameter, ParameterValue};
 #[doc(inline)]
@@ -200,6 +199,9 @@ pub use zenoh_backend::service::{Client, RmwRequestId, Server};
 #[cfg(feature = "zenoh")]
 #[doc(inline)]
 pub use zenoh_backend::action::{ActionClient, ActionServer, GoalId};
+#[cfg(feature = "zenoh")]
+#[doc(inline)]
+pub use zenoh_backend::parameters::{ParameterClient, ParameterEvent, ParameterServer};
 
 /// Module for stuff we do not want to export from top level;
 pub mod ros2 {

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,6 +1,8 @@
 //! `rosout` logging data types
 
+#[cfg(feature = "dds")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "dds")]
 use rustdds::*;
 
 /// Log message structure, communicated over the rosout Topic.
@@ -8,6 +10,10 @@ use rustdds::*;
 /// [Log](https://github.com/ros2/rcl_interfaces/blob/master/rcl_interfaces/msg/Log.msg)
 ///
 /// To write log messages, use the [`rosout`](crate::rosout!) macro.
+///
+/// Currently only available on the `dds` backend (uses a RustDDS `Timestamp`);
+/// the `zenoh` backend's rosout support lands with an owned timestamp (E9).
+#[cfg(feature = "dds")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Log {
   pub timestamp: Timestamp,
@@ -19,6 +25,7 @@ pub struct Log {
   pub line: u32,
 }
 
+#[cfg(feature = "dds")]
 impl Log {
   /// ROS2 logging severity level
   pub const DEBUG: u8 = 10;

--- a/src/names.rs
+++ b/src/names.rs
@@ -368,6 +368,16 @@ impl ServiceTypeName {
     self.msg.type_name()
   }
 
+  /// The base DDS-form service type name, e.g.
+  /// `example_interfaces::srv::dds_::AddTwoInts_` — used as the `<type>`
+  /// component of a Zenoh service key expression.
+  #[cfg(feature = "zenoh")]
+  pub(crate) fn dds_service_type(&self) -> String {
+    slash_to_colons(
+      self.package_name().to_owned() + "/" + &self.prefix + "/dds_/" + self.type_name() + "_",
+    )
+  }
+
   pub(crate) fn dds_request_type(&self) -> String {
     slash_to_colons(
       self.package_name().to_owned()

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -289,10 +289,20 @@ impl From<ParameterDescriptor> for raw::ParameterDescriptor {
 /// Raw, ROS2-compatible Parameters for sending over the wire.
 /// Not for use in a Rust application.
 pub mod raw {
-  use rustdds::*;
+  // `Timestamp` is only needed by the DDS backend's `ParameterEvent` (below).
+  // The Zenoh backend uses an owned `builtin_interfaces::Time` timestamp
+  // instead (see `zenoh_backend::parameters`), so the rest of this module is
+  // backend-neutral.
+  #[cfg(feature = "dds")]
+  use rustdds::Timestamp;
   use serde::{Deserialize, Serialize};
 
   /// ROS2 [ParameterEvent](https://github.com/ros2/rcl_interfaces/blob/master/rcl_interfaces/msg/ParameterEvent.msg)
+  ///
+  /// Only available on the `dds` backend, because its timestamp is a
+  /// `rustdds::Timestamp`. The Zenoh backend defines an owned equivalent in
+  /// [`crate::zenoh_backend::parameters`].
+  #[cfg(feature = "dds")]
   #[derive(Debug, Clone, Serialize, Deserialize)]
   pub struct ParameterEvent {
     pub timestamp: Timestamp,

--- a/src/qos.rs
+++ b/src/qos.rs
@@ -1,0 +1,312 @@
+//! Backend-neutral Quality-of-Service profile.
+//!
+//! [`QosProfile`] is `ros2-client`'s own representation of a ROS 2 QoS profile
+//! (the `rmw_qos_profile_t` knobs), independent of any middleware. It exists so
+//! the public API does not have to name a `rustdds` type — the `zenoh` backend
+//! cannot depend on `rustdds` (see
+//! `docs/decisions/0004-owned-public-types.md`).
+//!
+//! * On the **`dds`** backend it converts to/from [`rustdds::QosPolicies`]
+//!   (this module's `From` impls, gated on the `dds` feature).
+//! * On the **`zenoh`** backend it drives publisher/subscriber options and the
+//!   compact QoS encoding embedded in liveliness keys (E2/E5).
+//!
+//! This is the first step of E1; existing APIs still accept the RustDDS QoS
+//! types and are migrated incrementally.
+
+use std::time::Duration;
+
+/// Delivery guarantee.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Reliability {
+  /// Samples may be dropped.
+  BestEffort,
+  /// Lost samples are retransmitted.
+  Reliable,
+}
+
+/// Whether late-joining subscriptions receive previously-published samples.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Durability {
+  /// Only samples published while a subscription is alive are delivered.
+  Volatile,
+  /// Late joiners receive the last `depth` samples (latched/transient-local).
+  TransientLocal,
+}
+
+/// How many samples are retained.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum History {
+  /// Keep only the last `depth` samples.
+  KeepLast {
+    /// Number of samples retained.
+    depth: usize,
+  },
+  /// Keep all samples (bounded by resource limits / backpressure).
+  KeepAll,
+}
+
+/// Liveliness assertion policy. `ros2-client` (and `rmw_zenoh`) only support
+/// automatic liveliness; `ManualByTopic` is accepted for completeness.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Liveliness {
+  /// The middleware asserts liveliness automatically.
+  Automatic,
+  /// The application asserts liveliness per topic.
+  ManualByTopic,
+}
+
+/// A ROS 2 Quality-of-Service profile.
+///
+/// `deadline`, `lifespan`, and `liveliness_lease` use `None` to mean "infinite"
+/// (no deadline / never expires / infinite lease), matching the ROS 2 default.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QosProfile {
+  /// Reliability policy.
+  pub reliability: Reliability,
+  /// Durability policy.
+  pub durability: Durability,
+  /// History policy.
+  pub history: History,
+  /// Maximum expected time between samples; `None` = infinite (no deadline).
+  pub deadline: Option<Duration>,
+  /// Maximum time a sample is valid; `None` = infinite (never expires).
+  pub lifespan: Option<Duration>,
+  /// Liveliness policy.
+  pub liveliness: Liveliness,
+  /// Liveliness lease duration; `None` = infinite.
+  pub liveliness_lease: Option<Duration>,
+}
+
+impl QosProfile {
+  /// The ROS 2 "sensor data" style default used for subscriptions: best-effort,
+  /// volatile, keep-last depth 1, infinite deadline/lifespan, automatic
+  /// liveliness. Mirrors the DDS-spec defaults used by
+  /// `DEFAULT_SUBSCRIPTION_QOS`.
+  pub const fn subscription_default() -> Self {
+    Self {
+      reliability: Reliability::BestEffort,
+      durability: Durability::Volatile,
+      history: History::KeepLast { depth: 1 },
+      deadline: None,
+      lifespan: None,
+      liveliness: Liveliness::Automatic,
+      liveliness_lease: None,
+    }
+  }
+
+  /// The default used for publishers: like [`Self::subscription_default`] but
+  /// reliable (the DDS default for writers). Mirrors `DEFAULT_PUBLISHER_QOS`.
+  pub const fn publisher_default() -> Self {
+    Self {
+      reliability: Reliability::Reliable,
+      ..Self::subscription_default()
+    }
+  }
+
+  /// Builder-style setter for reliability.
+  #[must_use]
+  pub const fn reliability(mut self, reliability: Reliability) -> Self {
+    self.reliability = reliability;
+    self
+  }
+
+  /// Builder-style setter for durability.
+  #[must_use]
+  pub const fn durability(mut self, durability: Durability) -> Self {
+    self.durability = durability;
+    self
+  }
+
+  /// Builder-style setter for history.
+  #[must_use]
+  pub const fn history(mut self, history: History) -> Self {
+    self.history = history;
+    self
+  }
+}
+
+impl Default for QosProfile {
+  fn default() -> Self {
+    Self::subscription_default()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DDS backend conversions.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "dds")]
+mod dds_conv {
+  use rustdds::{policy, Duration as DdsDuration, QosPolicies, QosPolicyBuilder};
+
+  use super::{Durability, History, Liveliness, QosProfile, Reliability};
+
+  // Default DDS max_blocking_time for a Reliable writer/reader. RustDDS requires
+  // a value; ROS 2 QoS has no such knob, so we use the same 100 ms this crate
+  // already uses for DEFAULT_PUBLISHER_QOS.
+  const DEFAULT_MAX_BLOCKING: DdsDuration = DdsDuration::from_millis(100);
+
+  fn to_dds_duration(d: Option<std::time::Duration>) -> DdsDuration {
+    match d {
+      None => DdsDuration::INFINITE,
+      Some(d) => DdsDuration::from_nanos(d.as_nanos() as i64),
+    }
+  }
+
+  fn from_dds_duration(d: DdsDuration) -> Option<std::time::Duration> {
+    if d == DdsDuration::INFINITE {
+      None
+    } else {
+      Some(std::time::Duration::from_nanos(
+        d.to_nanoseconds().max(0) as u64
+      ))
+    }
+  }
+
+  impl From<&QosProfile> for QosPolicies {
+    fn from(p: &QosProfile) -> Self {
+      QosPolicyBuilder::new()
+        .durability(match p.durability {
+          Durability::Volatile => policy::Durability::Volatile,
+          Durability::TransientLocal => policy::Durability::TransientLocal,
+        })
+        .reliability(match p.reliability {
+          Reliability::BestEffort => policy::Reliability::BestEffort,
+          Reliability::Reliable => policy::Reliability::Reliable {
+            max_blocking_time: DEFAULT_MAX_BLOCKING,
+          },
+        })
+        .history(match p.history {
+          History::KeepLast { depth } => policy::History::KeepLast {
+            depth: depth as i32,
+          },
+          History::KeepAll => policy::History::KeepAll,
+        })
+        .liveliness(match p.liveliness {
+          Liveliness::Automatic => policy::Liveliness::Automatic {
+            lease_duration: to_dds_duration(p.liveliness_lease),
+          },
+          Liveliness::ManualByTopic => policy::Liveliness::ManualByTopic {
+            lease_duration: to_dds_duration(p.liveliness_lease),
+          },
+        })
+        .deadline(policy::Deadline(to_dds_duration(p.deadline)))
+        .lifespan(policy::Lifespan {
+          duration: to_dds_duration(p.lifespan),
+        })
+        .build()
+    }
+  }
+
+  impl From<QosProfile> for QosPolicies {
+    fn from(p: QosProfile) -> Self {
+      Self::from(&p)
+    }
+  }
+
+  impl From<&QosPolicies> for QosProfile {
+    fn from(q: &QosPolicies) -> Self {
+      let reliability = match q.reliability() {
+        Some(policy::Reliability::Reliable { .. }) => Reliability::Reliable,
+        _ => Reliability::BestEffort,
+      };
+      let durability = match q.durability() {
+        Some(policy::Durability::Volatile) | None => Durability::Volatile,
+        Some(_) => Durability::TransientLocal, // TransientLocal/Transient/Persistent
+      };
+      let history = match q.history() {
+        Some(policy::History::KeepAll) => History::KeepAll,
+        Some(policy::History::KeepLast { depth }) => History::KeepLast {
+          depth: depth.max(0) as usize,
+        },
+        None => History::KeepLast { depth: 1 },
+      };
+      let (liveliness, liveliness_lease) = match q.liveliness() {
+        Some(policy::Liveliness::ManualByTopic { lease_duration }) => {
+          (Liveliness::ManualByTopic, from_dds_duration(lease_duration))
+        }
+        Some(policy::Liveliness::Automatic { lease_duration }) => {
+          (Liveliness::Automatic, from_dds_duration(lease_duration))
+        }
+        Some(policy::Liveliness::ManualByParticipant { lease_duration }) => {
+          (Liveliness::Automatic, from_dds_duration(lease_duration))
+        }
+        None => (Liveliness::Automatic, None),
+      };
+      QosProfile {
+        reliability,
+        durability,
+        history,
+        deadline: q
+          .deadline()
+          .and_then(|policy::Deadline(d)| from_dds_duration(d)),
+        lifespan: q.lifespan().and_then(|ls| from_dds_duration(ls.duration)),
+        liveliness,
+        liveliness_lease,
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn defaults_match_intent() {
+    assert_eq!(
+      QosProfile::subscription_default().reliability,
+      Reliability::BestEffort
+    );
+    assert_eq!(
+      QosProfile::publisher_default().reliability,
+      Reliability::Reliable
+    );
+    assert_eq!(
+      QosProfile::default().history,
+      History::KeepLast { depth: 1 }
+    );
+  }
+
+  #[test]
+  fn builder_setters() {
+    let q = QosProfile::default()
+      .reliability(Reliability::Reliable)
+      .durability(Durability::TransientLocal)
+      .history(History::KeepLast { depth: 10 });
+    assert_eq!(q.reliability, Reliability::Reliable);
+    assert_eq!(q.durability, Durability::TransientLocal);
+    assert_eq!(q.history, History::KeepLast { depth: 10 });
+  }
+
+  #[cfg(feature = "dds")]
+  #[test]
+  fn roundtrips_through_rustdds() {
+    use std::time::Duration;
+    let profiles = [
+      QosProfile::subscription_default(),
+      QosProfile::publisher_default(),
+      QosProfile {
+        reliability: Reliability::Reliable,
+        durability: Durability::TransientLocal,
+        history: History::KeepLast { depth: 10 },
+        deadline: Some(Duration::from_millis(500)),
+        lifespan: Some(Duration::from_secs(10)),
+        liveliness: Liveliness::Automatic,
+        liveliness_lease: Some(Duration::from_secs(2)),
+      },
+      QosProfile {
+        history: History::KeepAll,
+        ..QosProfile::publisher_default()
+      },
+    ];
+    for p in profiles {
+      let dds: rustdds::QosPolicies = (&p).into();
+      let back: QosProfile = (&dds).into();
+      assert_eq!(p, back, "QoS did not round-trip through rustdds: {p:?}");
+    }
+  }
+}

--- a/src/rcl_interfaces.rs
+++ b/src/rcl_interfaces.rs
@@ -4,21 +4,33 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{parameters, service::AService, Message};
+use crate::{parameters, Message};
+// The `AService` type aliases below are DDS-service plumbing. The Zenoh backend
+// consumes the request/response structs directly (as `Server<Req, Resp>` /
+// `Client<Req, Resp>` payloads), so those structs stay backend-neutral while
+// the aliases are gated behind the `dds` feature.
+#[cfg(feature = "dds")]
+use crate::service::AService;
 
+#[cfg(feature = "dds")]
 pub type ListParametersService = AService<ListParametersRequest, ListParametersResponse>;
 
+#[cfg(feature = "dds")]
 pub type GetParametersService = AService<GetParametersRequest, GetParametersResponse>;
 
+#[cfg(feature = "dds")]
 pub type GetParameterTypesService = AService<GetParameterTypesRequest, GetParameterTypesResponse>;
 
+#[cfg(feature = "dds")]
 pub type SetParametersService = AService<SetParametersRequest, SetParametersResponse>;
 
+#[cfg(feature = "dds")]
 pub type DescribeParametersService =
   AService<DescribeParametersRequest, DescribeParametersResponse>;
 
 // This is structurally identical to SetParamtersService, but the operation
 // of the service is slightly different.
+#[cfg(feature = "dds")]
 pub type SetParametersAtomicallyService = AService<SetParametersRequest, SetParametersResponse>;
 
 #[allow(non_snake_case)]

--- a/src/ros_time.rs
+++ b/src/ros_time.rs
@@ -14,6 +14,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
 use log::error;
+#[cfg(feature = "dds")]
 use rustdds::Timestamp;
 
 /// ROS Time with nanosecond precision
@@ -83,6 +84,7 @@ impl From<ROSTime> for chrono::DateTime<Utc> {
 
 // rustDDS::Timestamp <-> ROSTime
 
+#[cfg(feature = "dds")]
 impl From<ROSTime> for Timestamp {
   fn from(rt: ROSTime) -> Timestamp {
     let chrono_time = chrono::DateTime::<Utc>::from(rt);
@@ -99,13 +101,15 @@ impl From<ROSTime> for Timestamp {
 /// and "2.3.3 DCPS PSM : IDL" for DDS `Time_t` type definitions and RTPS
 /// Specification v2.5 Section "8.3.2 Type Definitions" for RTPS view of
 /// `Time_t`.
+#[cfg(feature = "dds")]
 pub enum TimestampConversionError {
   /// DDS Timestamp indicates an invalid value
   Invalid,
-  /// DDS Timestamp indicates "infinity"  
+  /// DDS Timestamp indicates "infinity"
   Infinite,
 }
 
+#[cfg(feature = "dds")]
 impl TryFrom<Timestamp> for ROSTime {
   type Error = TimestampConversionError;
   fn try_from(ts: Timestamp) -> Result<ROSTime, TimestampConversionError> {

--- a/src/zenoh_backend/action.rs
+++ b/src/zenoh_backend/action.rs
@@ -1,0 +1,347 @@
+//! Zenoh actions (E7).
+//!
+//! ROS 2 actions have no middleware-level concept — they are composed of
+//! ordinary services + topics (see `docs/zenoh_study/research/rmw_zenoh.md`
+//! §8). This module builds that composition on top of the Zenoh service
+//! ([`super::service`]) and pub/sub ([`super::pubsub`]) layers:
+//!
+//! * `send_goal` service — `SendGoalRequest<G>` → `SendGoalResponse`
+//! * `get_result` service — `GetResultRequest` → `GetResultResponse<R>`
+//!   (queried with a long timeout, mirroring rmw_zenoh's `_action/get_result`)
+//! * `feedback` topic — `FeedbackMessage<F>`
+//!
+//! Goals are correlated by an application-level `GoalId` (a random UUID),
+//! exactly as in the DDS backend. `cancel_goal` and the `status` topic are
+//! follow-ups.
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use super::{
+  pubsub::{PublishError, Publisher, Subscription},
+  service::{Client, RmwRequestId, Server, ServiceError},
+};
+use crate::{builtin_interfaces::Time, unique_identifier_msgs::UUID};
+
+/// Application-level goal identifier.
+pub type GoalId = UUID;
+
+/// `action_msgs/GoalStatus` status codes.
+pub mod goal_status {
+  /// The goal is currently being executed.
+  pub const EXECUTING: i8 = 2;
+  /// The goal completed successfully.
+  pub const SUCCEEDED: i8 = 4;
+  /// The goal was aborted.
+  pub const ABORTED: i8 = 5;
+  /// The goal was canceled.
+  pub const CANCELED: i8 = 6;
+}
+
+/// `<Action>_SendGoal_Request` — a goal plus its id.
+#[derive(Serialize, Deserialize)]
+pub struct SendGoalRequest<G> {
+  /// Goal identifier.
+  pub goal_id: GoalId,
+  /// The goal payload.
+  pub goal: G,
+}
+
+/// `<Action>_SendGoal_Response` — whether the goal was accepted.
+#[derive(Serialize, Deserialize)]
+pub struct SendGoalResponse {
+  /// Whether the server accepted the goal.
+  pub accepted: bool,
+  /// Server timestamp when the decision was made.
+  pub stamp: Time,
+}
+
+/// `<Action>_GetResult_Request`.
+#[derive(Serialize, Deserialize)]
+pub struct GetResultRequest {
+  /// The goal whose result is requested.
+  pub goal_id: GoalId,
+}
+
+/// `<Action>_GetResult_Response` — terminal status + result.
+#[derive(Serialize, Deserialize)]
+pub struct GetResultResponse<R> {
+  /// Terminal goal status (see [`goal_status`]).
+  pub status: i8,
+  /// The result payload.
+  pub result: R,
+}
+
+/// `<Action>_FeedbackMessage` — feedback for a goal.
+#[derive(Serialize, Deserialize)]
+pub struct FeedbackMessage<F> {
+  /// The goal this feedback belongs to.
+  pub goal_id: GoalId,
+  /// The feedback payload.
+  pub feedback: F,
+}
+
+/// An action client: send goals, receive feedback, fetch results.
+pub struct ActionClient<G, R, F> {
+  send_goal: Client<SendGoalRequest<G>, SendGoalResponse>,
+  get_result: Client<GetResultRequest, GetResultResponse<R>>,
+  feedback: Subscription<FeedbackMessage<F>>,
+}
+
+impl<G: Serialize, R: DeserializeOwned, F: DeserializeOwned> ActionClient<G, R, F> {
+  pub(crate) fn new(
+    send_goal: Client<SendGoalRequest<G>, SendGoalResponse>,
+    get_result: Client<GetResultRequest, GetResultResponse<R>>,
+    feedback: Subscription<FeedbackMessage<F>>,
+  ) -> Self {
+    Self {
+      send_goal,
+      get_result,
+      feedback,
+    }
+  }
+
+  /// Send a goal (a fresh random `GoalId` is generated). Returns the id and
+  /// whether the server accepted it.
+  pub fn send_goal(&self, goal: G) -> Result<(GoalId, bool), ServiceError> {
+    let goal_id = UUID::new_random();
+    let resp = self.send_goal.call(SendGoalRequest { goal_id, goal })?;
+    Ok((goal_id, resp.accepted))
+  }
+
+  /// Fetch the result for a goal (blocks until the server responds).
+  pub fn get_result(&self, goal_id: GoalId) -> Result<(i8, R), ServiceError> {
+    let resp = self.get_result.call(GetResultRequest { goal_id })?;
+    Ok((resp.status, resp.result))
+  }
+
+  /// Take a feedback message if one is immediately available.
+  pub fn take_feedback(&self) -> Option<(GoalId, F)> {
+    match self.feedback.try_take() {
+      Ok(Some((msg, _info))) => Some((msg.goal_id, msg.feedback)),
+      _ => None,
+    }
+  }
+}
+
+/// An action server: accept goals, publish feedback, answer result requests.
+///
+/// This exposes the primitives; the goal state machine (accept/execute/succeed)
+/// is driven by the application, as in `ros2-client`'s DDS action server.
+pub struct ActionServer<G, R, F> {
+  send_goal: Server<SendGoalRequest<G>, SendGoalResponse>,
+  get_result: Server<GetResultRequest, GetResultResponse<R>>,
+  feedback: Publisher<FeedbackMessage<F>>,
+}
+
+impl<G: DeserializeOwned, R: Serialize, F: Serialize> ActionServer<G, R, F> {
+  pub(crate) fn new(
+    send_goal: Server<SendGoalRequest<G>, SendGoalResponse>,
+    get_result: Server<GetResultRequest, GetResultResponse<R>>,
+    feedback: Publisher<FeedbackMessage<F>>,
+  ) -> Self {
+    Self {
+      send_goal,
+      get_result,
+      feedback,
+    }
+  }
+
+  /// Take a pending goal request if available: `(request id, goal id, goal)`.
+  pub fn try_receive_goal(&self) -> Option<(RmwRequestId, GoalId, G)> {
+    match self.send_goal.try_receive_request() {
+      Ok(Some((id, req))) => Some((id, req.goal_id, req.goal)),
+      _ => None,
+    }
+  }
+
+  /// Respond to a goal request (accept/reject).
+  pub fn respond_goal(&self, id: RmwRequestId, accepted: bool) -> Result<(), ServiceError> {
+    self.send_goal.send_response(
+      id,
+      SendGoalResponse {
+        accepted,
+        stamp: Time::ZERO,
+      },
+    )
+  }
+
+  /// Publish feedback for a goal.
+  pub fn publish_feedback(&self, goal_id: GoalId, feedback: F) -> Result<(), PublishError> {
+    self.feedback.publish(FeedbackMessage { goal_id, feedback })
+  }
+
+  /// Take a pending result request if available: `(request id, goal id)`.
+  pub fn try_receive_result_request(&self) -> Option<(RmwRequestId, GoalId)> {
+    match self.get_result.try_receive_request() {
+      Ok(Some((id, req))) => Some((id, req.goal_id)),
+      _ => None,
+    }
+  }
+
+  /// Respond to a result request with the terminal status and result.
+  pub fn respond_result(
+    &self,
+    id: RmwRequestId,
+    status: i8,
+    result: R,
+  ) -> Result<(), ServiceError> {
+    self
+      .get_result
+      .send_response(id, GetResultResponse { status, result })
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use std::{
+    collections::BTreeMap,
+    sync::{
+      atomic::{AtomicBool, Ordering},
+      Arc,
+    },
+    time::{Duration, Instant},
+  };
+
+  use serde::{Deserialize, Serialize};
+  use zenoh::Config;
+
+  use super::{goal_status, ActionClient, ActionServer, GoalId};
+  use crate::{Context, ContextOptions, Name, NodeName, NodeOptions};
+
+  #[derive(Serialize, Deserialize)]
+  struct FibGoal {
+    order: i32,
+  }
+  #[derive(Serialize, Deserialize)]
+  struct FibResult {
+    sequence: Vec<i32>,
+  }
+  #[derive(Serialize, Deserialize)]
+  struct FibFeedback {
+    sequence: Vec<i32>,
+  }
+
+  fn make_config(listen_port: u16, connect_port: Option<u16>) -> Config {
+    let mut c = Config::default();
+    c.insert_json5("mode", "\"peer\"").unwrap();
+    c.insert_json5("scouting/multicast/enabled", "false")
+      .unwrap();
+    c.insert_json5(
+      "listen/endpoints",
+      &format!("[\"tcp/127.0.0.1:{listen_port}\"]"),
+    )
+    .unwrap();
+    if let Some(p) = connect_port {
+      c.insert_json5("connect/endpoints", &format!("[\"tcp/127.0.0.1:{p}\"]"))
+        .unwrap();
+    }
+    c
+  }
+
+  fn fibonacci(order: i32) -> Vec<i32> {
+    let mut seq = vec![0, 1];
+    for i in 2..order.max(2) as usize {
+      let next = seq[i - 1] + seq[i - 2];
+      seq.push(next);
+    }
+    seq
+  }
+
+  #[test]
+  fn fibonacci_action_roundtrip() {
+    use crate::ActionTypeName;
+
+    let srv_port = 17521;
+    let cli_port = 17522;
+    let srv_ctx =
+      Context::with_options(ContextOptions::new().zenoh_config(make_config(srv_port, None)))
+        .unwrap();
+    let cli_ctx = Context::with_options(
+      ContextOptions::new().zenoh_config(make_config(cli_port, Some(srv_port))),
+    )
+    .unwrap();
+
+    let srv_node = srv_ctx.new_node(
+      NodeName::new("/", "fib_server").unwrap(),
+      NodeOptions::new(),
+    );
+    let cli_node = cli_ctx.new_node(
+      NodeName::new("/", "fib_client").unwrap(),
+      NodeOptions::new(),
+    );
+    let atype = ActionTypeName::new("action_tutorials_interfaces", "Fibonacci");
+    let name = Name::new("/", "fibonacci").unwrap();
+
+    let server: ActionServer<FibGoal, FibResult, FibFeedback> =
+      srv_node.create_action_server(&name, &atype).unwrap();
+    let client: ActionClient<FibGoal, FibResult, FibFeedback> =
+      cli_node.create_action_client(&name, &atype).unwrap();
+
+    // Server: accept goals, compute+publish feedback, answer result requests.
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_srv = stop.clone();
+    let server_thread = std::thread::spawn(move || {
+      let deadline = Instant::now() + Duration::from_secs(30);
+      let mut results: BTreeMap<GoalId, Vec<i32>> = BTreeMap::new();
+      let mut pending: Vec<(crate::RmwRequestId, GoalId)> = Vec::new();
+      while !stop_srv.load(Ordering::Relaxed) && Instant::now() < deadline {
+        if let Some((id, goal_id, goal)) = server.try_receive_goal() {
+          let _ = server.respond_goal(id, true);
+          let seq = fibonacci(goal.order);
+          let _ = server.publish_feedback(
+            goal_id,
+            FibFeedback {
+              sequence: seq.clone(),
+            },
+          );
+          results.insert(goal_id, seq);
+        }
+        if let Some((id, goal_id)) = server.try_receive_result_request() {
+          pending.push((id, goal_id));
+        }
+        pending.retain(|(id, goal_id)| match results.get(goal_id) {
+          Some(seq) => {
+            let _ = server.respond_result(
+              *id,
+              goal_status::SUCCEEDED,
+              FibResult {
+                sequence: seq.clone(),
+              },
+            );
+            false
+          }
+          None => true,
+        });
+        std::thread::sleep(Duration::from_millis(20));
+      }
+    });
+
+    // Client: send a goal (retry until accepted), then fetch the result.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let goal_id = loop {
+      assert!(Instant::now() < deadline, "goal never accepted");
+      match client.send_goal(FibGoal { order: 5 }) {
+        Ok((gid, true)) => break gid,
+        _ => std::thread::sleep(Duration::from_millis(200)),
+      }
+    };
+
+    let mut outcome = None;
+    while Instant::now() < deadline {
+      if let Ok(res) = client.get_result(goal_id) {
+        outcome = Some(res);
+        break;
+      }
+      std::thread::sleep(Duration::from_millis(200));
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = server_thread.join();
+
+    let (status, result) = outcome.expect("no result received");
+    assert_eq!(status, goal_status::SUCCEEDED);
+    assert_eq!(result.sequence, vec![0, 1, 1, 2, 3]);
+  }
+}

--- a/src/zenoh_backend/action.rs
+++ b/src/zenoh_backend/action.rs
@@ -11,8 +11,10 @@
 //! * `feedback` topic — `FeedbackMessage<F>`
 //!
 //! Goals are correlated by an application-level `GoalId` (a random UUID),
-//! exactly as in the DDS backend. `cancel_goal` and the `status` topic are
-//! follow-ups.
+//! exactly as in the DDS backend. Alongside send_goal/get_result/feedback, the
+//! module also wires the `cancel_goal` service (`action_msgs/srv/CancelGoal`)
+//! and the `status` topic (`action_msgs/msg/GoalStatusArray`), completing the
+//! ROS 2 action surface.
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -20,7 +22,14 @@ use super::{
   pubsub::{PublishError, Publisher, Subscription},
   service::{Client, RmwRequestId, Server, ServiceError},
 };
-use crate::{builtin_interfaces::Time, unique_identifier_msgs::UUID};
+use crate::{
+  action_msgs::{
+    CancelGoalRequest, CancelGoalResponse, CancelGoalResponseEnum, GoalInfo, GoalStatus,
+    GoalStatusArray,
+  },
+  builtin_interfaces::Time,
+  unique_identifier_msgs::UUID,
+};
 
 /// Application-level goal identifier.
 pub type GoalId = UUID;
@@ -80,11 +89,14 @@ pub struct FeedbackMessage<F> {
   pub feedback: F,
 }
 
-/// An action client: send goals, receive feedback, fetch results.
+/// An action client: send goals, receive feedback, fetch results, cancel
+/// goals, and watch status.
 pub struct ActionClient<G, R, F> {
   send_goal: Client<SendGoalRequest<G>, SendGoalResponse>,
   get_result: Client<GetResultRequest, GetResultResponse<R>>,
   feedback: Subscription<FeedbackMessage<F>>,
+  cancel_goal: Client<CancelGoalRequest, CancelGoalResponse>,
+  status: Subscription<GoalStatusArray>,
 }
 
 impl<G: Serialize, R: DeserializeOwned, F: DeserializeOwned> ActionClient<G, R, F> {
@@ -92,11 +104,15 @@ impl<G: Serialize, R: DeserializeOwned, F: DeserializeOwned> ActionClient<G, R, 
     send_goal: Client<SendGoalRequest<G>, SendGoalResponse>,
     get_result: Client<GetResultRequest, GetResultResponse<R>>,
     feedback: Subscription<FeedbackMessage<F>>,
+    cancel_goal: Client<CancelGoalRequest, CancelGoalResponse>,
+    status: Subscription<GoalStatusArray>,
   ) -> Self {
     Self {
       send_goal,
       get_result,
       feedback,
+      cancel_goal,
+      status,
     }
   }
 
@@ -121,6 +137,36 @@ impl<G: Serialize, R: DeserializeOwned, F: DeserializeOwned> ActionClient<G, R, 
       _ => None,
     }
   }
+
+  /// Request cancellation of a single goal by id (blocks for the server's
+  /// [`CancelGoalResponse`]).
+  pub fn cancel_goal(&self, goal_id: GoalId) -> Result<CancelGoalResponse, ServiceError> {
+    self.cancel_goal.call(CancelGoalRequest {
+      goal_info: GoalInfo {
+        goal_id,
+        stamp: Time::ZERO,
+      },
+    })
+  }
+
+  /// Request cancellation of all goals (zero goal id + zero stamp, per the
+  /// `action_msgs/srv/CancelGoal` policy).
+  pub fn cancel_all_goals(&self) -> Result<CancelGoalResponse, ServiceError> {
+    self.cancel_goal.call(CancelGoalRequest {
+      goal_info: GoalInfo {
+        goal_id: UUID::ZERO,
+        stamp: Time::ZERO,
+      },
+    })
+  }
+
+  /// Take the latest goal-status array if one is immediately available.
+  pub fn take_status(&self) -> Option<GoalStatusArray> {
+    match self.status.try_take() {
+      Ok(Some((msg, _info))) => Some(msg),
+      _ => None,
+    }
+  }
 }
 
 /// An action server: accept goals, publish feedback, answer result requests.
@@ -131,6 +177,8 @@ pub struct ActionServer<G, R, F> {
   send_goal: Server<SendGoalRequest<G>, SendGoalResponse>,
   get_result: Server<GetResultRequest, GetResultResponse<R>>,
   feedback: Publisher<FeedbackMessage<F>>,
+  cancel_goal: Server<CancelGoalRequest, CancelGoalResponse>,
+  status: Publisher<GoalStatusArray>,
 }
 
 impl<G: DeserializeOwned, R: Serialize, F: Serialize> ActionServer<G, R, F> {
@@ -138,11 +186,15 @@ impl<G: DeserializeOwned, R: Serialize, F: Serialize> ActionServer<G, R, F> {
     send_goal: Server<SendGoalRequest<G>, SendGoalResponse>,
     get_result: Server<GetResultRequest, GetResultResponse<R>>,
     feedback: Publisher<FeedbackMessage<F>>,
+    cancel_goal: Server<CancelGoalRequest, CancelGoalResponse>,
+    status: Publisher<GoalStatusArray>,
   ) -> Self {
     Self {
       send_goal,
       get_result,
       feedback,
+      cancel_goal,
+      status,
     }
   }
 
@@ -188,6 +240,37 @@ impl<G: DeserializeOwned, R: Serialize, F: Serialize> ActionServer<G, R, F> {
     self
       .get_result
       .send_response(id, GetResultResponse { status, result })
+  }
+
+  /// Take a pending cancel request if available: `(request id, goal id)`.
+  /// A zero goal id means "cancel all" (see `action_msgs/srv/CancelGoal`).
+  pub fn try_receive_cancel(&self) -> Option<(RmwRequestId, GoalId)> {
+    match self.cancel_goal.try_receive_request() {
+      Ok(Some((id, req))) => Some((id, req.goal_info.goal_id)),
+      _ => None,
+    }
+  }
+
+  /// Respond to a cancel request with a return code and the goals now
+  /// transitioning to CANCELING.
+  pub fn respond_cancel(
+    &self,
+    id: RmwRequestId,
+    return_code: CancelGoalResponseEnum,
+    goals_canceling: Vec<GoalInfo>,
+  ) -> Result<(), ServiceError> {
+    self.cancel_goal.send_response(
+      id,
+      CancelGoalResponse {
+        return_code,
+        goals_canceling,
+      },
+    )
+  }
+
+  /// Publish the current goal-status array on the `status` topic.
+  pub fn publish_status(&self, status_list: Vec<GoalStatus>) -> Result<(), PublishError> {
+    self.status.publish(GoalStatusArray { status_list })
   }
 }
 
@@ -343,5 +426,140 @@ mod tests {
     let (status, result) = outcome.expect("no result received");
     assert_eq!(status, goal_status::SUCCEEDED);
     assert_eq!(result.sequence, vec![0, 1, 1, 2, 3]);
+  }
+
+  #[test]
+  fn cancel_and_status_roundtrip() {
+    use crate::{
+      action_msgs::{CancelGoalResponseEnum, GoalInfo, GoalStatus, GoalStatusEnum},
+      builtin_interfaces::Time,
+      ActionTypeName,
+    };
+
+    let srv_port = 17529;
+    let cli_port = 17530;
+    let srv_ctx =
+      Context::with_options(ContextOptions::new().zenoh_config(make_config(srv_port, None)))
+        .unwrap();
+    let cli_ctx = Context::with_options(
+      ContextOptions::new().zenoh_config(make_config(cli_port, Some(srv_port))),
+    )
+    .unwrap();
+
+    let srv_node = srv_ctx.new_node(
+      NodeName::new("/", "fib_server").unwrap(),
+      NodeOptions::new(),
+    );
+    let cli_node = cli_ctx.new_node(
+      NodeName::new("/", "fib_client").unwrap(),
+      NodeOptions::new(),
+    );
+    let atype = ActionTypeName::new("action_tutorials_interfaces", "Fibonacci");
+    let name = Name::new("/", "fibonacci").unwrap();
+
+    let server: ActionServer<FibGoal, FibResult, FibFeedback> =
+      srv_node.create_action_server(&name, &atype).unwrap();
+    let client: ActionClient<FibGoal, FibResult, FibFeedback> =
+      cli_node.create_action_client(&name, &atype).unwrap();
+
+    // Server: track goal statuses, publish the array each tick, and honour
+    // cancel requests by moving the goal to Canceled.
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_srv = stop.clone();
+    let server_thread = std::thread::spawn(move || {
+      let deadline = Instant::now() + Duration::from_secs(30);
+      let mut statuses: BTreeMap<GoalId, GoalStatusEnum> = BTreeMap::new();
+      while !stop_srv.load(Ordering::Relaxed) && Instant::now() < deadline {
+        if let Some((id, goal_id, _goal)) = server.try_receive_goal() {
+          let _ = server.respond_goal(id, true);
+          statuses.insert(goal_id, GoalStatusEnum::Executing);
+        }
+        if let Some((id, goal_id)) = server.try_receive_cancel() {
+          // Single-goal cancel (goal_id non-zero in this test).
+          let canceling = if statuses.contains_key(&goal_id) {
+            statuses.insert(goal_id, GoalStatusEnum::Canceled);
+            vec![GoalInfo {
+              goal_id,
+              stamp: Time::ZERO,
+            }]
+          } else {
+            vec![]
+          };
+          let code = if canceling.is_empty() {
+            CancelGoalResponseEnum::UnknownGoal
+          } else {
+            CancelGoalResponseEnum::None
+          };
+          let _ = server.respond_cancel(id, code, canceling);
+        }
+        // Publish the full status array every tick (as ROS action servers do).
+        let list: Vec<GoalStatus> = statuses
+          .iter()
+          .map(|(goal_id, status)| GoalStatus {
+            goal_info: GoalInfo {
+              goal_id: *goal_id,
+              stamp: Time::ZERO,
+            },
+            status: *status,
+          })
+          .collect();
+        let _ = server.publish_status(list);
+        std::thread::sleep(Duration::from_millis(20));
+      }
+    });
+
+    // Client: send a goal, observe Executing status, cancel it, observe Canceled.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let goal_id = loop {
+      assert!(Instant::now() < deadline, "goal never accepted");
+      match client.send_goal(FibGoal { order: 10 }) {
+        Ok((gid, true)) => break gid,
+        _ => std::thread::sleep(Duration::from_millis(200)),
+      }
+    };
+
+    let status_of = |gid: GoalId, want: GoalStatusEnum| -> bool {
+      let end = Instant::now() + Duration::from_secs(20);
+      while Instant::now() < end {
+        if let Some(array) = client.take_status() {
+          if array
+            .status_list
+            .iter()
+            .any(|s| s.goal_info.goal_id == gid && s.status == want)
+          {
+            return true;
+          }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+      }
+      false
+    };
+
+    assert!(
+      status_of(goal_id, GoalStatusEnum::Executing),
+      "never saw the goal reach Executing on /status"
+    );
+
+    // Cancel and check the response.
+    let resp = {
+      let end = Instant::now() + Duration::from_secs(20);
+      loop {
+        assert!(Instant::now() < end, "cancel never answered");
+        if let Ok(r) = client.cancel_goal(goal_id) {
+          break r;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+      }
+    };
+    assert_eq!(resp.return_code, CancelGoalResponseEnum::None);
+    assert!(resp.goals_canceling.iter().any(|g| g.goal_id == goal_id));
+
+    assert!(
+      status_of(goal_id, GoalStatusEnum::Canceled),
+      "never saw the goal reach Canceled on /status"
+    );
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = server_thread.join();
   }
 }

--- a/src/zenoh_backend/attachment.rs
+++ b/src/zenoh_backend/attachment.rs
@@ -1,0 +1,116 @@
+//! Message / request / response attachment (E2).
+//!
+//! Every Zenoh publication, service request, and service reply carries an
+//! attachment with three fields, in this order (see
+//! `docs/zenoh_study/research/rmw_zenoh.md` §4 and
+//! `docs/decisions/0008-gid-and-attachment-byte-parity.md`):
+//!
+//! 1. sequence number — `i64`
+//! 2. source timestamp — `i64`, nanoseconds since the UNIX epoch
+//! 3. source GID — 16-byte array
+//!
+//! The bytes are produced with the `zenoh-ext` serializer (the Rust counterpart
+//! of zenoh-cpp's `ext::Serializer`), which follows the Zenoh serialization
+//! RFC: integers are fixed little-endian, and the array is written with a
+//! varint length prefix. For the 16-byte GID that prefix is the single byte
+//! `0x10`, so the on-wire layout is:
+//!
+//! ```text
+//! | seq: 8B LE | source_ts: 8B LE | len=0x10 | gid: 16B |   (33 bytes)
+//! ```
+//!
+//! which is byte-for-byte what `rmw_zenoh` emits.
+
+use zenoh::bytes::ZBytes;
+use zenoh_ext::{ZDeserializer, ZSerializer};
+
+/// The three attachment fields carried alongside every message.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AttachmentData {
+  /// Per-publisher / per-client monotonic sequence number.
+  pub sequence_number: i64,
+  /// Source timestamp, nanoseconds since the UNIX epoch.
+  pub source_timestamp: i64,
+  /// 16-byte GID of the originating publisher / client.
+  pub source_gid: [u8; 16],
+}
+
+/// Failure to decode an [`AttachmentData`] from received bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AttachmentError;
+
+impl std::fmt::Display for AttachmentError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "malformed ROS 2 / Zenoh message attachment")
+  }
+}
+impl std::error::Error for AttachmentError {}
+
+impl AttachmentData {
+  /// Serialize to a Zenoh attachment `ZBytes`, byte-compatible with
+  /// `rmw_zenoh`.
+  pub fn to_zbytes(self) -> ZBytes {
+    let mut s = ZSerializer::new();
+    s.serialize(self.sequence_number);
+    s.serialize(self.source_timestamp);
+    s.serialize(self.source_gid);
+    s.finish()
+  }
+
+  /// Decode from a received Zenoh attachment.
+  pub fn from_zbytes(zbytes: &ZBytes) -> Result<Self, AttachmentError> {
+    let mut d = ZDeserializer::new(zbytes);
+    let sequence_number = d.deserialize::<i64>().map_err(|_| AttachmentError)?;
+    let source_timestamp = d.deserialize::<i64>().map_err(|_| AttachmentError)?;
+    let source_gid = d.deserialize::<[u8; 16]>().map_err(|_| AttachmentError)?;
+    Ok(Self {
+      sequence_number,
+      source_timestamp,
+      source_gid,
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn wire_layout_matches_rmw_zenoh() {
+    let a = AttachmentData {
+      sequence_number: 7,
+      source_timestamp: 0x0102_0304_0506_0708,
+      source_gid: [0xAB; 16],
+    };
+    let zbytes = a.to_zbytes();
+    let bytes = zbytes.to_bytes();
+
+    let mut expected = Vec::new();
+    expected.extend_from_slice(&7i64.to_le_bytes());
+    expected.extend_from_slice(&0x0102_0304_0506_0708i64.to_le_bytes());
+    expected.push(0x10); // varint length prefix of the 16-byte array
+    expected.extend_from_slice(&[0xAB; 16]);
+
+    assert_eq!(bytes.as_ref(), expected.as_slice());
+    assert_eq!(bytes.len(), 33);
+  }
+
+  #[test]
+  fn round_trips() {
+    let a = AttachmentData {
+      sequence_number: 42,
+      source_timestamp: 1_700_000_000_000_000_000,
+      source_gid: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    };
+    let decoded = AttachmentData::from_zbytes(&a.to_zbytes()).unwrap();
+    assert_eq!(a, decoded);
+  }
+
+  #[test]
+  fn rejects_truncated() {
+    let short = ZBytes::from(vec![1u8, 2, 3]);
+    assert_eq!(AttachmentData::from_zbytes(&short), Err(AttachmentError));
+  }
+}

--- a/src/zenoh_backend/cdr.rs
+++ b/src/zenoh_backend/cdr.rs
@@ -1,0 +1,128 @@
+//! CDR (de)serialization for the Zenoh backend (E2/E4).
+//!
+//! ROS 2 message payloads are OMG CDR with a 4-byte *encapsulation header*
+//! (a 2-byte representation identifier + 2-byte options) followed by the CDR
+//! body. `rmw_zenoh` carries exactly these bytes as the Zenoh payload, so the
+//! Zenoh backend must produce the same.
+//!
+//! The DDS backend gets CDR through RustDDS; here we use the standalone
+//! [`cdr-encoding`] crate (same author as RustDDS) for the body and prepend the
+//! header ourselves — `cdr-encoding` serializes the body *without* the
+//! encapsulation header (see its docs). See
+//! `docs/decisions/0003-reuse-cdr-serialization.md`.
+//!
+//! [`cdr-encoding`]: https://docs.rs/cdr-encoding
+
+use byteorder::{BigEndian, LittleEndian};
+use cdr_encoding::{from_bytes, to_vec};
+use serde::{de::DeserializeOwned, Serialize};
+
+/// The 4-byte encapsulation header for little-endian plain CDR: representation
+/// identifier `CDR_LE` (`0x0001`) followed by zero options.
+pub const CDR_LE_HEADER: [u8; 4] = [0x00, 0x01, 0x00, 0x00];
+
+/// Failure to (de)serialize a ROS 2 CDR payload.
+#[derive(Debug)]
+pub enum CdrError {
+  /// The underlying `cdr-encoding` serializer/deserializer failed.
+  Encoding(cdr_encoding::Error),
+  /// The payload is too short to contain the 4-byte encapsulation header.
+  MissingHeader,
+}
+
+impl std::fmt::Display for CdrError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      CdrError::Encoding(e) => write!(f, "CDR encoding error: {e}"),
+      CdrError::MissingHeader => write!(f, "CDR payload missing 4-byte encapsulation header"),
+    }
+  }
+}
+
+impl std::error::Error for CdrError {}
+
+/// Serialize a message to a ROS 2 CDR payload: the 4-byte `CDR_LE`
+/// encapsulation header followed by the little-endian CDR body.
+pub fn to_cdr<M: Serialize>(msg: &M) -> Result<Vec<u8>, CdrError> {
+  let body = to_vec::<M, LittleEndian>(msg).map_err(CdrError::Encoding)?;
+  let mut out = Vec::with_capacity(CDR_LE_HEADER.len() + body.len());
+  out.extend_from_slice(&CDR_LE_HEADER);
+  out.extend_from_slice(&body);
+  Ok(out)
+}
+
+/// Deserialize a ROS 2 CDR payload (with its 4-byte encapsulation header) into
+/// `M`, honouring the representation identifier's endianness (`CDR_LE` vs
+/// `CDR_BE`, including the parameter-list variants).
+pub fn from_cdr<M: DeserializeOwned>(bytes: &[u8]) -> Result<M, CdrError> {
+  if bytes.len() < 4 {
+    return Err(CdrError::MissingHeader);
+  }
+  let body = &bytes[4..];
+  // Representation identifier is bytes[0..2]; the low bit of the second byte
+  // selects little-endian (CDR_LE=0x0001, PL_CDR_LE=0x0003) vs big-endian
+  // (CDR_BE=0x0000, PL_CDR_BE=0x0002).
+  let little_endian = (bytes[1] & 0x01) == 0x01;
+  let (msg, _consumed) = if little_endian {
+    from_bytes::<M, LittleEndian>(body).map_err(CdrError::Encoding)?
+  } else {
+    from_bytes::<M, BigEndian>(body).map_err(CdrError::Encoding)?
+  };
+  Ok(msg)
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use serde::{Deserialize, Serialize};
+
+  use super::*;
+
+  #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+  struct AddTwoIntsRequest {
+    a: i64,
+    b: i64,
+  }
+
+  #[test]
+  fn header_is_prepended_once() {
+    let bytes = to_cdr(&"hello".to_string()).unwrap();
+    assert_eq!(&bytes[0..4], &CDR_LE_HEADER);
+    // A CDR string is: u32 length (incl. NUL) + chars + NUL. "hello" -> len 6.
+    // header(4) + len(4) + 6 = 14 bytes; the point is the header appears once.
+    assert!(bytes.len() >= 4 + 4 + 6);
+  }
+
+  #[test]
+  fn round_trips_string_and_struct() {
+    let s = "chatter message".to_string();
+    assert_eq!(from_cdr::<String>(&to_cdr(&s).unwrap()).unwrap(), s);
+
+    let req = AddTwoIntsRequest { a: 2, b: 40 };
+    assert_eq!(
+      from_cdr::<AddTwoIntsRequest>(&to_cdr(&req).unwrap()).unwrap(),
+      req
+    );
+  }
+
+  #[test]
+  fn decodes_big_endian_payload() {
+    // Build a CDR_BE payload by hand and confirm from_cdr honours the header.
+    let body = to_vec::<AddTwoIntsRequest, BigEndian>(&AddTwoIntsRequest { a: 7, b: 8 }).unwrap();
+    let mut be = vec![0x00, 0x00, 0x00, 0x00]; // CDR_BE header
+    be.extend_from_slice(&body);
+    assert_eq!(
+      from_cdr::<AddTwoIntsRequest>(&be).unwrap(),
+      AddTwoIntsRequest { a: 7, b: 8 }
+    );
+  }
+
+  #[test]
+  fn rejects_missing_header() {
+    assert!(matches!(
+      from_cdr::<String>(&[0x00, 0x01]),
+      Err(CdrError::MissingHeader)
+    ));
+  }
+}

--- a/src/zenoh_backend/context.rs
+++ b/src/zenoh_backend/context.rs
@@ -11,9 +11,13 @@ use std::sync::{
   Arc,
 };
 
-use zenoh::{Config, Session, Wait};
+use zenoh::{pubsub::Subscriber, sample::SampleKind, Config, Session, Wait};
 
-use super::node::{Node, NodeOptions};
+use super::{
+  graph_cache::GraphCache,
+  keyexpr,
+  node::{Node, NodeOptions},
+};
 use crate::names::NodeName;
 
 /// Builder for configuring a [`Context`] on the Zenoh backend.
@@ -66,6 +70,9 @@ struct ContextInner {
   session: Session,
   domain_id: u16,
   next_node_id: AtomicU64,
+  graph_cache: Arc<GraphCache>,
+  // Kept alive to keep the graph cache updating; dropped => subscriber undeclared.
+  _liveliness_subscriber: Subscriber<()>,
 }
 
 impl Context {
@@ -80,13 +87,48 @@ impl Context {
   pub fn with_options(opt: ContextOptions) -> zenoh::Result<Context> {
     let config = opt.config.unwrap_or_else(default_config);
     let session = zenoh::open(config).wait()?;
+
+    // Build the ROS graph cache from liveliness tokens: subscribe over the whole
+    // domain admin space with history so existing entities are delivered too.
+    let graph_cache = Arc::new(GraphCache::default());
+    let cache_for_cb = graph_cache.clone();
+    let liveliness_subscriber = session
+      .liveliness()
+      .declare_subscriber(keyexpr::graph_cache_keyexpr(opt.domain_id))
+      .history(true)
+      .callback(move |sample| {
+        let key = sample.key_expr().as_str();
+        match sample.kind() {
+          SampleKind::Put => cache_for_cb.apply_put(key),
+          SampleKind::Delete => cache_for_cb.apply_delete(key),
+        }
+      })
+      .wait()?;
+
     Ok(Context {
       inner: Arc::new(ContextInner {
         session,
         domain_id: opt.domain_id,
         next_node_id: AtomicU64::new(0),
+        graph_cache,
+        _liveliness_subscriber: liveliness_subscriber,
       }),
     })
+  }
+
+  /// Number of publishers currently discovered on `topic` (fully-qualified).
+  pub fn publisher_count(&self, topic: &str) -> usize {
+    self.inner.graph_cache.publisher_count(topic)
+  }
+
+  /// Number of subscriptions currently discovered on `topic`.
+  pub fn subscription_count(&self, topic: &str) -> usize {
+    self.inner.graph_cache.subscription_count(topic)
+  }
+
+  /// Fully-qualified names of all currently discovered nodes.
+  pub fn node_names(&self) -> Vec<String> {
+    self.inner.graph_cache.node_names()
   }
 
   /// Create a new ROS 2 [`Node`] on this context's session.
@@ -137,7 +179,10 @@ fn default_config() -> Config {
 
 #[cfg(test)]
 mod tests {
+  use std::time::{Duration, Instant};
+
   use super::*;
+  use crate::{MessageTypeName, Name, NodeName, NodeOptions, Publisher, QosProfile};
 
   #[test]
   fn opens_a_session_and_keeps_domain_id() {
@@ -147,5 +192,49 @@ mod tests {
     // Cloning shares the same session handle.
     let ctx2 = ctx.clone();
     assert_eq!(ctx2.domain_id(), 7);
+  }
+
+  fn make_config(listen_port: u16, connect_port: Option<u16>) -> Config {
+    let mut c = Config::default();
+    c.insert_json5("mode", "\"peer\"").unwrap();
+    c.insert_json5("scouting/multicast/enabled", "false")
+      .unwrap();
+    c.insert_json5(
+      "listen/endpoints",
+      &format!("[\"tcp/127.0.0.1:{listen_port}\"]"),
+    )
+    .unwrap();
+    if let Some(p) = connect_port {
+      c.insert_json5("connect/endpoints", &format!("[\"tcp/127.0.0.1:{p}\"]"))
+        .unwrap();
+    }
+    c
+  }
+
+  #[test]
+  fn graph_cache_discovers_remote_publisher_and_node() {
+    let a_port = 17517;
+    let b_port = 17518;
+    let ctx_a =
+      Context::with_options(ContextOptions::new().zenoh_config(make_config(a_port, None))).unwrap();
+    let ctx_b =
+      Context::with_options(ContextOptions::new().zenoh_config(make_config(b_port, Some(a_port))))
+        .unwrap();
+
+    let node_a = ctx_a.new_node(NodeName::new("/", "talker").unwrap(), NodeOptions::new());
+    let topic = node_a.create_topic(
+      &Name::new("/", "chatter").unwrap(),
+      MessageTypeName::new("std_msgs", "String"),
+      &QosProfile::publisher_default(),
+    );
+    let _publisher: Publisher<String> = node_a.create_publisher(&topic, None).unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline && ctx_b.publisher_count("/chatter") == 0 {
+      std::thread::sleep(Duration::from_millis(100));
+    }
+
+    assert_eq!(ctx_b.publisher_count("/chatter"), 1);
+    assert!(ctx_b.node_names().contains(&"/talker".to_string()));
   }
 }

--- a/src/zenoh_backend/context.rs
+++ b/src/zenoh_backend/context.rs
@@ -6,9 +6,15 @@
 //! it opens the session and holds the domain id (used as the key-expression
 //! prefix). Node/pub/sub/service creation is added by E4–E6.
 
-use std::sync::Arc;
+use std::sync::{
+  atomic::{AtomicU64, Ordering},
+  Arc,
+};
 
 use zenoh::{Config, Session, Wait};
+
+use super::node::{Node, NodeOptions};
+use crate::names::NodeName;
 
 /// Builder for configuring a [`Context`] on the Zenoh backend.
 pub struct ContextOptions {
@@ -59,6 +65,7 @@ pub struct Context {
 struct ContextInner {
   session: Session,
   domain_id: u16,
+  next_node_id: AtomicU64,
 }
 
 impl Context {
@@ -77,8 +84,15 @@ impl Context {
       inner: Arc::new(ContextInner {
         session,
         domain_id: opt.domain_id,
+        next_node_id: AtomicU64::new(0),
       }),
     })
+  }
+
+  /// Create a new ROS 2 [`Node`] on this context's session.
+  pub fn new_node(&self, name: NodeName, options: NodeOptions) -> Node {
+    let node_id = self.inner.next_node_id.fetch_add(1, Ordering::Relaxed);
+    Node::new(self.clone(), name, node_id, options)
   }
 
   /// The ROS domain id (key-expression prefix) for this context.

--- a/src/zenoh_backend/context.rs
+++ b/src/zenoh_backend/context.rs
@@ -84,8 +84,16 @@ impl Context {
   }
 
   /// Open a new context with the given options.
+  ///
+  /// When no explicit [`ContextOptions::zenoh_config`] is given, the session
+  /// config is taken from the environment (see [`config_from_env`]): a JSON5
+  /// file named by `ZENOH_SESSION_CONFIG_URI`, or the built-in peer default,
+  /// with `ZENOH_CONFIG_OVERRIDE` applied on top. This matches `rmw_zenoh`.
   pub fn with_options(opt: ContextOptions) -> zenoh::Result<Context> {
-    let config = opt.config.unwrap_or_else(default_config);
+    let config = match opt.config {
+      Some(config) => config,
+      None => config_from_env()?,
+    };
     let session = zenoh::open(config).wait()?;
 
     // Build the ROS graph cache from liveliness tokens: subscribe over the whole
@@ -150,6 +158,52 @@ impl Context {
   }
 }
 
+/// Build a Zenoh [`Config`] from the environment, mirroring `rmw_zenoh`:
+///
+/// * `ZENOH_SESSION_CONFIG_URI` — if set (and non-empty), a path to a JSON5
+///   Zenoh config file loaded as the base config. Otherwise [`default_config`]
+///   is the base.
+/// * `ZENOH_CONFIG_OVERRIDE` — if set, a `;`-separated list of `key=value`
+///   JSON5 assignments applied on top of the base (e.g.
+///   `mode="client";connect/endpoints=["tcp/localhost:7447"]`).
+///
+/// A malformed override, or a config file that fails to load, is returned as an
+/// error rather than silently ignored.
+pub(crate) fn config_from_env() -> zenoh::Result<Config> {
+  let mut config = match std::env::var("ZENOH_SESSION_CONFIG_URI") {
+    Ok(uri) if !uri.trim().is_empty() => {
+      Config::from_file(uri.trim()).map_err(|e| -> zenoh::Error {
+        format!("failed to load Zenoh config from ZENOH_SESSION_CONFIG_URI={uri:?}: {e}").into()
+      })?
+    }
+    _ => default_config(),
+  };
+  if let Ok(overrides) = std::env::var("ZENOH_CONFIG_OVERRIDE") {
+    apply_config_overrides(&mut config, &overrides)?;
+  }
+  Ok(config)
+}
+
+/// Apply a `;`-separated list of `key=value` JSON5 assignments to `config`.
+/// Empty entries are ignored; an entry without `=` is an error.
+fn apply_config_overrides(config: &mut Config, overrides: &str) -> zenoh::Result<()> {
+  for entry in overrides
+    .split(';')
+    .map(str::trim)
+    .filter(|s| !s.is_empty())
+  {
+    let (key, value) = entry.split_once('=').ok_or_else(|| -> zenoh::Error {
+      format!("ZENOH_CONFIG_OVERRIDE entry is not `key=value`: {entry:?}").into()
+    })?;
+    config
+      .insert_json5(key.trim(), value.trim())
+      .map_err(|e| -> zenoh::Error {
+        format!("ZENOH_CONFIG_OVERRIDE failed for key {:?}: {e}", key.trim()).into()
+      })?;
+  }
+  Ok(())
+}
+
 /// Default Zenoh configuration for a ROS 2 peer.
 ///
 /// Peer mode, listening on an IPv4 loopback port and with multicast scouting
@@ -158,9 +212,10 @@ impl Context {
 /// (Zenoh's own default listens on `tcp/[::]:0`, which fails where IPv6 is
 /// unavailable, e.g. many CI runners).
 ///
-/// TODO(E3): load the full `rmw_zenoh` JSON5 profile (connect
-/// `tcp/localhost:7447`, gossip on, timestamping on) and honour
-/// `ZENOH_SESSION_CONFIG_URI` / `ZENOH_CONFIG_OVERRIDE`.
+/// For a full `rmw_zenoh`-style deployment (connect to `tcp/localhost:7447`,
+/// gossip scouting, timestamping) point `ZENOH_SESSION_CONFIG_URI` at the
+/// desired JSON5 file or supply `ZENOH_CONFIG_OVERRIDE` (see
+/// [`config_from_env`]).
 fn default_config() -> Config {
   let mut config = Config::default();
   // These keys are stable Zenoh config paths; a failure here is a programming
@@ -183,6 +238,24 @@ mod tests {
 
   use super::*;
   use crate::{MessageTypeName, Name, NodeName, NodeOptions, Publisher, QosProfile};
+
+  #[test]
+  fn config_overrides_apply_and_validate() {
+    // A well-formed override list applies cleanly...
+    let mut config = default_config();
+    apply_config_overrides(
+      &mut config,
+      "mode=\"client\"; connect/endpoints=[\"tcp/localhost:7447\"]",
+    )
+    .expect("valid overrides should apply");
+    assert_eq!(config.mode(), &Some(zenoh::config::WhatAmI::Client));
+
+    // ...empty entries are ignored...
+    apply_config_overrides(&mut default_config(), " ; ; ").expect("empty entries ignored");
+
+    // ...and an entry without `=` is rejected.
+    assert!(apply_config_overrides(&mut default_config(), "no_equals_here").is_err());
+  }
 
   #[test]
   fn opens_a_session_and_keeps_domain_id() {

--- a/src/zenoh_backend/context.rs
+++ b/src/zenoh_backend/context.rs
@@ -348,6 +348,78 @@ mod tests {
     assert!(ctx_b.node_names().contains(&"/talker".to_string()));
   }
 
+  // A client-mode config that reaches its session only through a Zenoh router
+  // (no direct peer link, no multicast) — the `rmw_zenoh` / ADR-0009 topology.
+  fn client_config(router_port: u16) -> Config {
+    let mut c = Config::default();
+    c.insert_json5("mode", "\"client\"").unwrap();
+    c.insert_json5("scouting/multicast/enabled", "false")
+      .unwrap();
+    c.insert_json5(
+      "connect/endpoints",
+      &format!("[\"tcp/127.0.0.1:{router_port}\"]"),
+    )
+    .unwrap();
+    c
+  }
+
+  // End-to-end through a real in-process Zenoh router: two client-mode contexts
+  // that can only see each other via the router exchange a message on /chatter.
+  // This exercises the router path (ADR-0009) that the peer-mode loopback tests
+  // do not.
+  #[test]
+  fn pub_sub_through_router() {
+    let router_port = 17540;
+    let mut router_conf = Config::default();
+    router_conf.insert_json5("mode", "\"router\"").unwrap();
+    router_conf
+      .insert_json5("scouting/multicast/enabled", "false")
+      .unwrap();
+    router_conf
+      .insert_json5(
+        "listen/endpoints",
+        &format!("[\"tcp/127.0.0.1:{router_port}\"]"),
+      )
+      .unwrap();
+    let _router = zenoh::open(router_conf).wait().expect("start zenoh router");
+
+    let sub_ctx =
+      Context::with_options(ContextOptions::new().zenoh_config(client_config(router_port)))
+        .expect("subscriber client context");
+    let pub_ctx =
+      Context::with_options(ContextOptions::new().zenoh_config(client_config(router_port)))
+        .expect("publisher client context");
+
+    let sub_node = sub_ctx.new_node(NodeName::new("/", "rsub").unwrap(), NodeOptions::new());
+    let pub_node = pub_ctx.new_node(NodeName::new("/", "rpub").unwrap(), NodeOptions::new());
+
+    let make_topic = |n: &crate::Node| {
+      n.create_topic(
+        &Name::new("/", "chatter").unwrap(),
+        MessageTypeName::new("std_msgs", "String"),
+        &QosProfile::default(),
+      )
+    };
+    let sub: crate::Subscription<String> = sub_node
+      .create_subscription(&make_topic(&sub_node), None)
+      .unwrap();
+    let publisher: Publisher<String> = pub_node
+      .create_publisher(&make_topic(&pub_node), None)
+      .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut got = None;
+    while Instant::now() < deadline {
+      publisher.publish("via router".to_string()).unwrap();
+      if let Some((msg, _)) = sub.try_take().unwrap() {
+        got = Some(msg);
+        break;
+      }
+      std::thread::sleep(Duration::from_millis(100));
+    }
+    assert_eq!(got.as_deref(), Some("via router"));
+  }
+
   #[test]
   fn wait_for_publisher_resolves_on_discovery() {
     let a_port = 17527;

--- a/src/zenoh_backend/context.rs
+++ b/src/zenoh_backend/context.rs
@@ -11,11 +11,12 @@ use std::sync::{
   Arc,
 };
 
+use async_channel::Receiver;
 use zenoh::{pubsub::Subscriber, sample::SampleKind, Config, Session, Wait};
 
 use super::{
-  graph_cache::GraphCache,
-  keyexpr,
+  graph_cache::{GraphCache, GraphEvent},
+  keyexpr::{self, EntityKind},
   node::{Node, NodeOptions},
 };
 use crate::names::NodeName;
@@ -137,6 +138,42 @@ impl Context {
   /// Fully-qualified names of all currently discovered nodes.
   pub fn node_names(&self) -> Vec<String> {
     self.inner.graph_cache.node_names()
+  }
+
+  /// Subscribe to ROS graph changes. Each returned stream receives every
+  /// subsequent [`GraphEvent`] (entity declared/undeclared); drop it to
+  /// unsubscribe. The backend-neutral alternative to polling
+  /// `publisher_count`/`node_names`.
+  pub fn graph_event_stream(&self) -> Receiver<GraphEvent> {
+    self.inner.graph_cache.subscribe()
+  }
+
+  /// Resolve once at least one publisher on `topic` (fully-qualified) is
+  /// discovered — immediately if one already exists.
+  pub async fn wait_for_publisher(&self, topic: &str) {
+    self.wait_for(EntityKind::Publisher, topic).await
+  }
+
+  /// Resolve once at least one subscription on `topic` is discovered —
+  /// immediately if one already exists.
+  pub async fn wait_for_subscription(&self, topic: &str) {
+    self.wait_for(EntityKind::Subscription, topic).await
+  }
+
+  async fn wait_for(&self, kind: EntityKind, name: &str) {
+    // Subscribe *before* checking the current count, so an entity that appears
+    // between the check and the subscription is not missed.
+    let stream = self.inner.graph_cache.subscribe();
+    if self.inner.graph_cache.count_kind_on_topic(kind, name) > 0 {
+      return;
+    }
+    while let Ok(event) = stream.recv().await {
+      if let GraphEvent::EntityDeclared(e) = event {
+        if e.kind == kind && e.name.as_deref() == Some(name) {
+          return;
+        }
+      }
+    }
   }
 
   /// Create a new ROS 2 [`Node`] on this context's session.
@@ -309,5 +346,37 @@ mod tests {
 
     assert_eq!(ctx_b.publisher_count("/chatter"), 1);
     assert!(ctx_b.node_names().contains(&"/talker".to_string()));
+  }
+
+  #[test]
+  fn wait_for_publisher_resolves_on_discovery() {
+    let a_port = 17527;
+    let b_port = 17528;
+    let ctx_a =
+      Context::with_options(ContextOptions::new().zenoh_config(make_config(a_port, None))).unwrap();
+    let ctx_b =
+      Context::with_options(ContextOptions::new().zenoh_config(make_config(b_port, Some(a_port))))
+        .unwrap();
+
+    // Start waiting on ctx_b before the publisher exists.
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+    let ctx_b_waiter = ctx_b.clone();
+    std::thread::spawn(move || {
+      futures::executor::block_on(ctx_b_waiter.wait_for_publisher("/chatter"));
+      let _ = done_tx.send(());
+    });
+
+    // Now create the publisher on ctx_a.
+    let node_a = ctx_a.new_node(NodeName::new("/", "talker").unwrap(), NodeOptions::new());
+    let topic = node_a.create_topic(
+      &Name::new("/", "chatter").unwrap(),
+      MessageTypeName::new("std_msgs", "String"),
+      &QosProfile::publisher_default(),
+    );
+    let _publisher: Publisher<String> = node_a.create_publisher(&topic, None).unwrap();
+
+    done_rx
+      .recv_timeout(Duration::from_secs(15))
+      .expect("wait_for_publisher did not resolve after the publisher appeared");
   }
 }

--- a/src/zenoh_backend/context.rs
+++ b/src/zenoh_backend/context.rs
@@ -1,0 +1,137 @@
+//! Zenoh [`Context`] — one `zenoh::Session` per ROS 2 context (E3).
+//!
+//! Mirrors the `rmw_zenoh` model where a ROS 2 context maps to a single Zenoh
+//! session shared by all of its entities (see
+//! `docs/decisions/0009-zenoh-router-and-config.md`). This is the seed of E3:
+//! it opens the session and holds the domain id (used as the key-expression
+//! prefix). Node/pub/sub/service creation is added by E4–E6.
+
+use std::sync::Arc;
+
+use zenoh::{Config, Session, Wait};
+
+/// Builder for configuring a [`Context`] on the Zenoh backend.
+pub struct ContextOptions {
+  domain_id: u16,
+  config: Option<Config>,
+}
+
+impl ContextOptions {
+  /// New options with defaults (domain id 0, default Zenoh peer config).
+  pub fn new() -> Self {
+    Self {
+      domain_id: 0,
+      config: None,
+    }
+  }
+
+  /// Set the ROS domain id. On the Zenoh backend this is not a transport
+  /// setting; it becomes the leading component of every key expression, which
+  /// is what isolates domains (see `docs/zenoh_study/research/rmw_zenoh.md`
+  /// §2).
+  pub fn domain_id(mut self, domain_id: u16) -> Self {
+    self.domain_id = domain_id;
+    self
+  }
+
+  /// Provide an explicit Zenoh [`Config`] (e.g. loaded from a JSON5 file).
+  /// If unset, a default peer configuration is used.
+  pub fn zenoh_config(mut self, config: Config) -> Self {
+    self.config = Some(config);
+    self
+  }
+}
+
+impl Default for ContextOptions {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+/// A ROS 2 [`Context`] backed by a single Zenoh session.
+///
+/// Cloning is cheap (a shared handle), matching the DDS backend's `Context`.
+#[derive(Clone)]
+pub struct Context {
+  inner: Arc<ContextInner>,
+}
+
+struct ContextInner {
+  session: Session,
+  domain_id: u16,
+}
+
+impl Context {
+  /// Open a new context with default settings (domain id 0, default peer
+  /// config). Requires a reachable Zenoh router in the default configuration
+  /// (see ADR-0009); opening still succeeds without one and connects later.
+  pub fn new() -> zenoh::Result<Context> {
+    Self::with_options(ContextOptions::new())
+  }
+
+  /// Open a new context with the given options.
+  pub fn with_options(opt: ContextOptions) -> zenoh::Result<Context> {
+    let config = opt.config.unwrap_or_else(default_config);
+    let session = zenoh::open(config).wait()?;
+    Ok(Context {
+      inner: Arc::new(ContextInner {
+        session,
+        domain_id: opt.domain_id,
+      }),
+    })
+  }
+
+  /// The ROS domain id (key-expression prefix) for this context.
+  pub fn domain_id(&self) -> u16 {
+    self.inner.domain_id
+  }
+
+  /// The underlying Zenoh session, shared by all entities in this context.
+  /// Used by pub/sub, discovery, and services (E4–E6).
+  #[allow(dead_code)] // consumed by later work items
+  pub(crate) fn session(&self) -> &Session {
+    &self.inner.session
+  }
+}
+
+/// Default Zenoh configuration for a ROS 2 peer.
+///
+/// Peer mode, listening on an IPv4 loopback port and with multicast scouting
+/// disabled — the same shape as `rmw_zenoh`'s default session config, which
+/// also keeps the crate working in IPv6-less / restricted-network environments
+/// (Zenoh's own default listens on `tcp/[::]:0`, which fails where IPv6 is
+/// unavailable, e.g. many CI runners).
+///
+/// TODO(E3): load the full `rmw_zenoh` JSON5 profile (connect
+/// `tcp/localhost:7447`, gossip on, timestamping on) and honour
+/// `ZENOH_SESSION_CONFIG_URI` / `ZENOH_CONFIG_OVERRIDE`.
+fn default_config() -> Config {
+  let mut config = Config::default();
+  // These keys are stable Zenoh config paths; a failure here is a programming
+  // error, so surface it loudly rather than silently opening a wrong config.
+  config
+    .insert_json5("mode", "\"peer\"")
+    .expect("valid zenoh config key: mode");
+  config
+    .insert_json5("listen/endpoints", "[\"tcp/127.0.0.1:0\"]")
+    .expect("valid zenoh config key: listen/endpoints");
+  config
+    .insert_json5("scouting/multicast/enabled", "false")
+    .expect("valid zenoh config key: scouting/multicast/enabled");
+  config
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn opens_a_session_and_keeps_domain_id() {
+    let ctx = Context::with_options(ContextOptions::new().domain_id(7))
+      .expect("opening a Zenoh session should succeed (peer mode, no router needed to open)");
+    assert_eq!(ctx.domain_id(), 7);
+    // Cloning shares the same session handle.
+    let ctx2 = ctx.clone();
+    assert_eq!(ctx2.domain_id(), 7);
+  }
+}

--- a/src/zenoh_backend/gid.rs
+++ b/src/zenoh_backend/gid.rs
@@ -5,8 +5,8 @@
 //! 128-bit XXH3 hash of that entity's liveliness key string, laid out as
 //! `gid[0..8] = low64`, `gid[8..16] = high64`, each in little-endian order.
 //!
-//! `u128::to_le_bytes()` produces exactly that layout (least-significant 8 bytes
-//! = `low64` LE, next 8 = `high64` LE), so the mapping is a single call.
+//! `u128::to_le_bytes()` produces exactly that layout (least-significant 8
+//! bytes = `low64` LE, next 8 = `high64` LE), so the mapping is a single call.
 //!
 //! Byte-for-byte parity with `rmw_zenoh`'s "simplified" XXH3-128 is asserted by
 //! live interop; this module fixes the layout and determinism.

--- a/src/zenoh_backend/gid.rs
+++ b/src/zenoh_backend/gid.rs
@@ -1,0 +1,70 @@
+//! Zenoh-backend entity GID derivation.
+//!
+//! Per `docs/decisions/0008-gid-and-attachment-byte-parity.md` and
+//! `rmw_zenoh` `liveliness_utils.cpp`, the 16-byte RMW GID of an entity is the
+//! 128-bit XXH3 hash of that entity's liveliness key string, laid out as
+//! `gid[0..8] = low64`, `gid[8..16] = high64`, each in little-endian order.
+//!
+//! `u128::to_le_bytes()` produces exactly that layout (least-significant 8 bytes
+//! = `low64` LE, next 8 = `high64` LE), so the mapping is a single call.
+//!
+//! Byte-for-byte parity with `rmw_zenoh`'s "simplified" XXH3-128 is asserted by
+//! live interop; this module fixes the layout and determinism.
+
+use xxhash_rust::xxh3::xxh3_128;
+
+/// Number of bytes in a Zenoh-backend GID (RMW `RMW_GID_STORAGE_SIZE`).
+pub const GID_LEN: usize = 16;
+
+/// Compute the 16-byte entity GID from its liveliness key expression string.
+pub fn gid_from_liveliness_key(liveliness_key: &str) -> [u8; GID_LEN] {
+  xxh3_128(liveliness_key.as_bytes()).to_le_bytes()
+}
+
+/// Lowercase hex rendering of a GID, matching the `Gid` `Debug` format.
+pub fn gid_hex(gid: &[u8; GID_LEN]) -> String {
+  let mut s = String::with_capacity(GID_LEN * 2);
+  for b in gid {
+    s.push_str(&format!("{b:02x}"));
+  }
+  s
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn deterministic_and_16_bytes() {
+    let key = "@ros2_lv/0/aac3178e146ba6f1fc6e6a4085e77f21/0/0/NN/%/%/listener";
+    let a = gid_from_liveliness_key(key);
+    let b = gid_from_liveliness_key(key);
+    assert_eq!(a, b);
+    assert_eq!(a.len(), 16);
+    // Distinct keys yield distinct GIDs (overwhelmingly likely).
+    assert_ne!(gid_from_liveliness_key("a"), gid_from_liveliness_key("b"));
+  }
+
+  #[test]
+  fn byte_layout_is_low64_then_high64_le() {
+    // Independently reconstruct the rmw layout (low64 LE || high64 LE) and
+    // confirm it equals our single to_le_bytes() call.
+    let key = "some/liveliness/key";
+    let h = xxh3_128(key.as_bytes());
+    let low = (h & 0xFFFF_FFFF_FFFF_FFFF) as u64;
+    let high = (h >> 64) as u64;
+    let mut expect = [0u8; 16];
+    expect[0..8].copy_from_slice(&low.to_le_bytes());
+    expect[8..16].copy_from_slice(&high.to_le_bytes());
+    assert_eq!(gid_from_liveliness_key(key), expect);
+  }
+
+  #[test]
+  fn hex_rendering() {
+    let gid = [0x00, 0x01, 0x0a, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    assert!(gid_hex(&gid).starts_with("00010aff"));
+    assert_eq!(gid_hex(&gid).len(), 32);
+  }
+}

--- a/src/zenoh_backend/graph_cache.rs
+++ b/src/zenoh_backend/graph_cache.rs
@@ -162,7 +162,9 @@ fn join_fqn(namespace: &str, name: &str) -> String {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::zenoh_backend::keyexpr::{entity_liveliness_keyexpr, node_liveliness_keyexpr, EntityIds};
+  use crate::zenoh_backend::keyexpr::{
+    entity_liveliness_keyexpr, node_liveliness_keyexpr, EntityIds,
+  };
 
   fn ids(entity_id: u64) -> EntityIds<'static> {
     EntityIds {

--- a/src/zenoh_backend/graph_cache.rs
+++ b/src/zenoh_backend/graph_cache.rs
@@ -162,9 +162,7 @@ fn join_fqn(namespace: &str, name: &str) -> String {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::zenoh_backend::keyexpr::{
-    entity_liveliness_keyexpr, node_liveliness_keyexpr, EntityIds,
-  };
+  use crate::zenoh_backend::keyexpr::{entity_liveliness_keyexpr, node_liveliness_keyexpr, EntityIds};
 
   fn ids(entity_id: u64) -> EntityIds<'static> {
     EntityIds {

--- a/src/zenoh_backend/graph_cache.rs
+++ b/src/zenoh_backend/graph_cache.rs
@@ -1,0 +1,142 @@
+//! In-memory ROS 2 graph cache built from liveliness tokens (E5).
+//!
+//! A [`Context`](super::context::Context) declares a liveliness subscriber over
+//! `@ros2_lv/<domain>/**`; each PUT/DELETE sample is fed to [`GraphCache`],
+//! which parses the token key ([`parse_liveliness_key`]) and maintains the set
+//! of live entities. Queries (entity counts, node names) read this set — the
+//! Zenoh analogue of the DDS `ros_discovery_info` graph.
+//!
+//! The parsing/query logic is backend-neutral (no `zenoh` crate), so it is
+//! unit-tested on any build.
+
+use std::{collections::HashMap, sync::Mutex};
+
+use super::keyexpr::{parse_liveliness_key, EntityKind, ParsedEntity};
+
+/// A thread-safe cache of discovered ROS 2 entities, keyed by their liveliness
+/// token key expression.
+#[derive(Default)]
+pub struct GraphCache {
+  entities: Mutex<HashMap<String, ParsedEntity>>,
+}
+
+impl GraphCache {
+  /// Record an entity from a liveliness-token PUT. Non-token keys are ignored.
+  pub fn apply_put(&self, key: &str) {
+    if let Some(entity) = parse_liveliness_key(key) {
+      self.entities.lock().unwrap().insert(key.to_owned(), entity);
+    }
+  }
+
+  /// Remove an entity on a liveliness-token DELETE.
+  pub fn apply_delete(&self, key: &str) {
+    self.entities.lock().unwrap().remove(key);
+  }
+
+  fn count_kind_on_topic(&self, kind: EntityKind, topic: &str) -> usize {
+    self
+      .entities
+      .lock()
+      .unwrap()
+      .values()
+      .filter(|e| e.kind == kind && e.topic_name.as_deref() == Some(topic))
+      .count()
+  }
+
+  /// Number of discovered publishers on a topic (by fully-qualified name).
+  pub fn publisher_count(&self, topic: &str) -> usize {
+    self.count_kind_on_topic(EntityKind::Publisher, topic)
+  }
+
+  /// Number of discovered subscriptions on a topic.
+  pub fn subscription_count(&self, topic: &str) -> usize {
+    self.count_kind_on_topic(EntityKind::Subscription, topic)
+  }
+
+  /// Number of discovered service servers on a service name.
+  pub fn service_server_count(&self, service: &str) -> usize {
+    self.count_kind_on_topic(EntityKind::ServiceServer, service)
+  }
+
+  /// Fully-qualified names of all discovered nodes, sorted and de-duplicated.
+  pub fn node_names(&self) -> Vec<String> {
+    let guard = self.entities.lock().unwrap();
+    let mut names: Vec<String> = guard
+      .values()
+      .filter(|e| e.kind == EntityKind::Node)
+      .map(|e| join_fqn(&e.namespace, &e.node_name))
+      .collect();
+    names.sort();
+    names.dedup();
+    names
+  }
+
+  /// Total number of cached entities (all kinds). Mainly for diagnostics/tests.
+  pub fn len(&self) -> usize {
+    self.entities.lock().unwrap().len()
+  }
+
+  /// Whether the cache is empty.
+  pub fn is_empty(&self) -> bool {
+    self.entities.lock().unwrap().is_empty()
+  }
+}
+
+fn join_fqn(namespace: &str, name: &str) -> String {
+  if namespace.is_empty() || namespace == "/" {
+    format!("/{name}")
+  } else {
+    format!("{namespace}/{name}")
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::zenoh_backend::keyexpr::{
+    entity_liveliness_keyexpr, node_liveliness_keyexpr, EntityIds,
+  };
+
+  fn ids(entity_id: u64) -> EntityIds<'static> {
+    EntityIds {
+      session_id: "aac3178e146ba6f1fc6e6a4085e77f21",
+      node_id: 0,
+      entity_id,
+      enclave: "",
+      namespace: "",
+      node_name: "talker",
+    }
+  }
+
+  #[test]
+  fn tracks_entities_and_counts() {
+    let cache = GraphCache::default();
+    let node_key = node_liveliness_keyexpr(0, &ids(0));
+    let pub_key = entity_liveliness_keyexpr(
+      0,
+      &ids(1),
+      EntityKind::Publisher,
+      "/chatter",
+      "std_msgs::msg::dds_::String_",
+      "RIHS01_x",
+      "::,7:,:,:,,",
+    );
+
+    cache.apply_put(&node_key);
+    cache.apply_put(&pub_key);
+    // A non-token key is ignored.
+    cache.apply_put("0/chatter/std_msgs::msg::dds_::String_/hash");
+
+    assert_eq!(cache.publisher_count("/chatter"), 1);
+    assert_eq!(cache.subscription_count("/chatter"), 0);
+    assert_eq!(cache.node_names(), vec!["/talker".to_string()]);
+    assert_eq!(cache.len(), 2);
+
+    // DELETE removes the publisher.
+    cache.apply_delete(&pub_key);
+    assert_eq!(cache.publisher_count("/chatter"), 0);
+    assert_eq!(cache.len(), 1);
+  }
+}

--- a/src/zenoh_backend/graph_cache.rs
+++ b/src/zenoh_backend/graph_cache.rs
@@ -11,29 +11,96 @@
 
 use std::{collections::HashMap, sync::Mutex};
 
+use async_channel::{Receiver, Sender};
+
 use super::keyexpr::{parse_liveliness_key, EntityKind, ParsedEntity};
+
+/// A change in the ROS 2 graph, delivered by
+/// [`Context::graph_event_stream`](super::context::Context::graph_event_stream).
+///
+/// Backend-neutral: the same shape would be produced by the DDS backend's
+/// discovery (ADR-0004). It replaces the RustDDS-specific `NodeEvent::DDS` for
+/// graph observation on the Zenoh backend.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GraphEvent {
+  /// An entity became visible in the graph.
+  EntityDeclared(GraphEntity),
+  /// An entity was removed from the graph.
+  EntityUndeclared(GraphEntity),
+}
+
+/// A discovered ROS 2 graph entity (backend-neutral view of a liveliness
+/// token).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GraphEntity {
+  /// What kind of entity this is.
+  pub kind: EntityKind,
+  /// Fully-qualified name of the owning node (e.g. `/robot1/talker`).
+  pub node_name: String,
+  /// Topic/service name (`None` for a node entity).
+  pub name: Option<String>,
+  /// DDS-form type name (`None` for a node entity).
+  pub type_name: Option<String>,
+}
+
+impl From<&ParsedEntity> for GraphEntity {
+  fn from(e: &ParsedEntity) -> Self {
+    GraphEntity {
+      kind: e.kind,
+      node_name: join_fqn(&e.namespace, &e.node_name),
+      name: e.topic_name.clone(),
+      type_name: e.type_name.clone(),
+    }
+  }
+}
 
 /// A thread-safe cache of discovered ROS 2 entities, keyed by their liveliness
 /// token key expression.
 #[derive(Default)]
 pub struct GraphCache {
   entities: Mutex<HashMap<String, ParsedEntity>>,
+  // Fan-out event subscribers (one unbounded channel per `subscribe()` caller),
+  // mirroring the DDS backend's `status_event_senders`.
+  subscribers: Mutex<Vec<Sender<GraphEvent>>>,
 }
 
 impl GraphCache {
   /// Record an entity from a liveliness-token PUT. Non-token keys are ignored.
   pub fn apply_put(&self, key: &str) {
     if let Some(entity) = parse_liveliness_key(key) {
+      let event = GraphEvent::EntityDeclared(GraphEntity::from(&entity));
       self.entities.lock().unwrap().insert(key.to_owned(), entity);
+      self.broadcast(event);
     }
   }
 
   /// Remove an entity on a liveliness-token DELETE.
   pub fn apply_delete(&self, key: &str) {
-    self.entities.lock().unwrap().remove(key);
+    let removed = self.entities.lock().unwrap().remove(key);
+    if let Some(entity) = removed {
+      self.broadcast(GraphEvent::EntityUndeclared(GraphEntity::from(&entity)));
+    }
   }
 
-  fn count_kind_on_topic(&self, kind: EntityKind, topic: &str) -> usize {
+  /// Register a new event stream. Each subscriber receives every subsequent
+  /// [`GraphEvent`]; drop the receiver to unsubscribe.
+  pub fn subscribe(&self) -> Receiver<GraphEvent> {
+    let (tx, rx) = async_channel::unbounded();
+    self.subscribers.lock().unwrap().push(tx);
+    rx
+  }
+
+  fn broadcast(&self, event: GraphEvent) {
+    let mut subs = self.subscribers.lock().unwrap();
+    // Drop closed receivers; deliver to the rest (unbounded => only fails if
+    // closed).
+    subs.retain(|s| !s.is_closed());
+    for s in subs.iter() {
+      let _ = s.try_send(event.clone());
+    }
+  }
+
+  pub(crate) fn count_kind_on_topic(&self, kind: EntityKind, topic: &str) -> usize {
     self
       .entities
       .lock()
@@ -138,5 +205,41 @@ mod tests {
     cache.apply_delete(&pub_key);
     assert_eq!(cache.publisher_count("/chatter"), 0);
     assert_eq!(cache.len(), 1);
+  }
+
+  #[test]
+  fn emits_declared_and_undeclared_events() {
+    let cache = GraphCache::default();
+    let stream = cache.subscribe();
+    let pub_key = entity_liveliness_keyexpr(
+      0,
+      &ids(1),
+      EntityKind::Publisher,
+      "/chatter",
+      "std_msgs::msg::dds_::String_",
+      "RIHS01_x",
+      "::,7:,:,:,,",
+    );
+
+    cache.apply_put(&pub_key);
+    cache.apply_delete(&pub_key);
+    // A non-token key produces no event.
+    cache.apply_put("0/chatter/not-a-token");
+
+    let declared = stream.try_recv().expect("a declared event");
+    match declared {
+      GraphEvent::EntityDeclared(e) => {
+        assert_eq!(e.kind, EntityKind::Publisher);
+        assert_eq!(e.name.as_deref(), Some("/chatter"));
+        assert_eq!(e.node_name, "/talker");
+      }
+      other => panic!("expected EntityDeclared, got {:?}", other),
+    }
+    match stream.try_recv().expect("an undeclared event") {
+      GraphEvent::EntityUndeclared(e) => assert_eq!(e.kind, EntityKind::Publisher),
+      other => panic!("expected EntityUndeclared, got {:?}", other),
+    }
+    // No third event (the non-token PUT was ignored).
+    assert!(stream.try_recv().is_err());
   }
 }

--- a/src/zenoh_backend/keyexpr.rs
+++ b/src/zenoh_backend/keyexpr.rs
@@ -1,0 +1,270 @@
+//! Zenoh key-expression construction for the ROS 2 ↔ Zenoh mapping.
+//!
+//! Two families of keys, both defined by the official `rmw_zenoh` (see
+//! `docs/zenoh_study/research/rmw_zenoh.md` §2–§3):
+//!
+//! * **Data-plane topic/service keys** — `<domain>/<name>/<type>/<type_hash>`,
+//!   with the *real* namespace slashes preserved in the name.
+//! * **Liveliness (discovery) keys** — under the `@ros2_lv` admin space, with
+//!   the name **mangled** (`/`→`%`, empty→`%`) because Zenoh liveliness keys may
+//!   not contain empty chunks.
+//!
+//! This module is pure string manipulation and carries no dependency on the
+//! `zenoh` crate, so it is unit-tested on every build.
+
+/// Admin-space prefix for ROS 2 liveliness tokens (`rmw_zenoh` `ADMIN_SPACE`).
+pub const ADMIN_SPACE: &str = "@ros2_lv";
+
+/// Two-letter entity kind codes used in liveliness keys.
+///
+/// From `rmw_zenoh` `liveliness_utils.cpp`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EntityKind {
+  /// Node.
+  Node,
+  /// Message publisher.
+  Publisher,
+  /// Message subscription.
+  Subscription,
+  /// Service server.
+  ServiceServer,
+  /// Service client.
+  ServiceClient,
+}
+
+impl EntityKind {
+  /// The two-letter code as it appears in a liveliness key.
+  pub const fn code(self) -> &'static str {
+    match self {
+      EntityKind::Node => "NN",
+      EntityKind::Publisher => "MP",
+      EntityKind::Subscription => "MS",
+      EntityKind::ServiceServer => "SS",
+      EntityKind::ServiceClient => "SC",
+    }
+  }
+}
+
+/// Mangle a ROS name for use in a liveliness key: `/`→`%`, and an empty string
+/// becomes a single `%` (Zenoh keys cannot contain empty chunks).
+pub fn mangle(name: &str) -> String {
+  if name.is_empty() {
+    "%".to_owned()
+  } else {
+    name.replace('/', "%")
+  }
+}
+
+/// Inverse of [`mangle`]: `%`→`/`. Note a lone `%` demangles to `/` (the root /
+/// empty case is inherently ambiguous and callers treat `/` and empty alike).
+pub fn demangle(name: &str) -> String {
+  name.replace('%', "/")
+}
+
+/// Strip a single leading and trailing `/` from a fully-qualified name, keeping
+/// interior slashes. `/chatter` → `chatter`, `/robot1/chatter` →
+/// `robot1/chatter`.
+fn strip_slashes(fq_name: &str) -> &str {
+  fq_name.trim_matches('/')
+}
+
+/// Build a data-plane topic (or service) key expression:
+/// `<domain>/<name>/<type>/<type_hash>`.
+///
+/// `fq_name` is the fully-qualified topic/service name (leading/trailing slashes
+/// are stripped, interior slashes kept). `type_name` is the DDS-form type name
+/// (e.g. `std_msgs::msg::dds_::String_`), `type_hash` the REP-2016 `RIHS01_…`
+/// string (or a wildcard for liberal receivers, see [`super::type_hash`]).
+pub fn topic_keyexpr(domain_id: u16, fq_name: &str, type_name: &str, type_hash: &str) -> String {
+  format!(
+    "{}/{}/{}/{}",
+    domain_id,
+    strip_slashes(fq_name),
+    type_name,
+    type_hash
+  )
+}
+
+/// Fields common to every liveliness token.
+#[derive(Clone, Debug)]
+pub struct EntityIds<'a> {
+  /// Zenoh session id (one per context), hex.
+  pub session_id: &'a str,
+  /// Node id within the context.
+  pub node_id: u64,
+  /// Entity id within the node. For a node token this equals `node_id`.
+  pub entity_id: u64,
+  /// SROS enclave, unmangled; empty for the default.
+  pub enclave: &'a str,
+  /// Node namespace, unmangled (e.g. `/` or `/robot1`).
+  pub namespace: &'a str,
+  /// Node base name.
+  pub node_name: &'a str,
+}
+
+/// Build a **node** liveliness key (`NN`), 9 components:
+/// `@ros2_lv/<domain>/<zid>/<nid>/<nid>/NN/<enclave>/<namespace>/<node>`.
+pub fn node_liveliness_keyexpr(domain_id: u16, ids: &EntityIds) -> String {
+  format!(
+    "{admin}/{domain}/{zid}/{nid}/{nid}/{kind}/{enclave}/{ns}/{node}",
+    admin = ADMIN_SPACE,
+    domain = domain_id,
+    zid = ids.session_id,
+    nid = ids.node_id,
+    kind = EntityKind::Node.code(),
+    enclave = mangle(ids.enclave),
+    ns = mangle(ids.namespace),
+    node = mangle(ids.node_name),
+  )
+}
+
+/// Build a publisher / subscription / service liveliness key.
+///
+/// `qualified_name` is the fully-qualified topic/service name (e.g. `/chatter`);
+/// it is mangled. `qos` is the compact QoS encoding string (opaque here — see
+/// the QoS-encoding work item; callers pass the already-encoded value).
+#[allow(clippy::too_many_arguments)]
+pub fn entity_liveliness_keyexpr(
+  domain_id: u16,
+  ids: &EntityIds,
+  kind: EntityKind,
+  qualified_name: &str,
+  type_name: &str,
+  type_hash: &str,
+  qos: &str,
+) -> String {
+  format!(
+    "{admin}/{domain}/{zid}/{nid}/{eid}/{kind}/{enclave}/{ns}/{node}/{name}/{ty}/{hash}/{qos}",
+    admin = ADMIN_SPACE,
+    domain = domain_id,
+    zid = ids.session_id,
+    nid = ids.node_id,
+    eid = ids.entity_id,
+    kind = kind.code(),
+    enclave = mangle(ids.enclave),
+    ns = mangle(ids.namespace),
+    node = mangle(ids.node_name),
+    name = mangle(qualified_name),
+    ty = type_name,
+    hash = type_hash,
+    qos = qos,
+  )
+}
+
+/// The liveliness key expression a context subscribes to (and queries) to build
+/// its graph cache: `@ros2_lv/<domain>/**`.
+pub fn graph_cache_keyexpr(domain_id: u16) -> String {
+  format!("{ADMIN_SPACE}/{domain_id}/**")
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // Concrete type hashes from docs/zenoh_study/research/rmw_zenoh.md examples.
+  const STRING_HASH: &str =
+    "RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18";
+  const ADDTWOINTS_HASH: &str =
+    "RIHS01_e118de6bf5eeb66a2491b5bda11202e7b68f198d6f67922cf30364858239c81a";
+
+  #[test]
+  fn topic_key_matches_rmw_zenoh_examples() {
+    assert_eq!(
+      topic_keyexpr(0, "/chatter", "std_msgs::msg::dds_::String_", STRING_HASH),
+      format!("0/chatter/std_msgs::msg::dds_::String_/{STRING_HASH}")
+    );
+    // Namespaced: interior slash kept, leading slash stripped.
+    assert_eq!(
+      topic_keyexpr(
+        0,
+        "/robot1/chatter",
+        "std_msgs::msg::dds_::String_",
+        STRING_HASH
+      ),
+      format!("0/robot1/chatter/std_msgs::msg::dds_::String_/{STRING_HASH}")
+    );
+    // Service key on domain 2.
+    assert_eq!(
+      topic_keyexpr(
+        2,
+        "/add_two_ints",
+        "example_interfaces::srv::dds_::AddTwoInts_",
+        ADDTWOINTS_HASH
+      ),
+      format!("2/add_two_ints/example_interfaces::srv::dds_::AddTwoInts_/{ADDTWOINTS_HASH}")
+    );
+  }
+
+  #[test]
+  fn mangling_roundtrips_and_handles_empty() {
+    assert_eq!(mangle(""), "%");
+    assert_eq!(mangle("/"), "%");
+    assert_eq!(mangle("/chatter"), "%chatter");
+    assert_eq!(mangle("/robot1/chatter"), "%robot1%chatter");
+    assert_eq!(demangle("%chatter"), "/chatter");
+    assert_eq!(demangle("%robot1%chatter"), "/robot1/chatter");
+  }
+
+  #[test]
+  fn node_liveliness_key_matches_example() {
+    // @ros2_lv/0/aac3178e146ba6f1fc6e6a4085e77f21/0/0/NN/%/%/listener
+    let ids = EntityIds {
+      session_id: "aac3178e146ba6f1fc6e6a4085e77f21",
+      node_id: 0,
+      entity_id: 0,
+      enclave: "",
+      namespace: "",
+      node_name: "listener",
+    };
+    assert_eq!(
+      node_liveliness_keyexpr(0, &ids),
+      "@ros2_lv/0/aac3178e146ba6f1fc6e6a4085e77f21/0/0/NN/%/%/listener"
+    );
+  }
+
+  #[test]
+  fn subscription_liveliness_key_matches_example() {
+    // @ros2_lv/0/aac.../0/10/MS/%/%/listener/%chatter/std_msgs::msg::dds_::String_/<hash>/::,10:,:,:,,
+    let ids = EntityIds {
+      session_id: "aac3178e146ba6f1fc6e6a4085e77f21",
+      node_id: 0,
+      entity_id: 10,
+      enclave: "",
+      namespace: "",
+      node_name: "listener",
+    };
+    let key = entity_liveliness_keyexpr(
+      0,
+      &ids,
+      EntityKind::Subscription,
+      "/chatter",
+      "std_msgs::msg::dds_::String_",
+      STRING_HASH,
+      "::,10:,:,:,,",
+    );
+    assert_eq!(
+      key,
+      format!(
+        "@ros2_lv/0/aac3178e146ba6f1fc6e6a4085e77f21/0/10/MS/%/%/listener/%chatter/\
+         std_msgs::msg::dds_::String_/{STRING_HASH}/::,10:,:,:,,"
+      )
+    );
+  }
+
+  #[test]
+  fn entity_kind_codes() {
+    assert_eq!(EntityKind::Node.code(), "NN");
+    assert_eq!(EntityKind::Publisher.code(), "MP");
+    assert_eq!(EntityKind::Subscription.code(), "MS");
+    assert_eq!(EntityKind::ServiceServer.code(), "SS");
+    assert_eq!(EntityKind::ServiceClient.code(), "SC");
+  }
+
+  #[test]
+  fn graph_cache_key() {
+    assert_eq!(graph_cache_keyexpr(0), "@ros2_lv/0/**");
+    assert_eq!(graph_cache_keyexpr(42), "@ros2_lv/42/**");
+  }
+}

--- a/src/zenoh_backend/keyexpr.rs
+++ b/src/zenoh_backend/keyexpr.rs
@@ -6,8 +6,8 @@
 //! * **Data-plane topic/service keys** — `<domain>/<name>/<type>/<type_hash>`,
 //!   with the *real* namespace slashes preserved in the name.
 //! * **Liveliness (discovery) keys** — under the `@ros2_lv` admin space, with
-//!   the name **mangled** (`/`→`%`, empty→`%`) because Zenoh liveliness keys may
-//!   not contain empty chunks.
+//!   the name **mangled** (`/`→`%`, empty→`%`) because Zenoh liveliness keys
+//!   may not contain empty chunks.
 //!
 //! This module is pure string manipulation and carries no dependency on the
 //! `zenoh` crate, so it is unit-tested on every build.
@@ -71,10 +71,11 @@ fn strip_slashes(fq_name: &str) -> &str {
 /// Build a data-plane topic (or service) key expression:
 /// `<domain>/<name>/<type>/<type_hash>`.
 ///
-/// `fq_name` is the fully-qualified topic/service name (leading/trailing slashes
-/// are stripped, interior slashes kept). `type_name` is the DDS-form type name
-/// (e.g. `std_msgs::msg::dds_::String_`), `type_hash` the REP-2016 `RIHS01_…`
-/// string (or a wildcard for liberal receivers, see [`super::type_hash`]).
+/// `fq_name` is the fully-qualified topic/service name (leading/trailing
+/// slashes are stripped, interior slashes kept). `type_name` is the DDS-form
+/// type name (e.g. `std_msgs::msg::dds_::String_`), `type_hash` the REP-2016
+/// `RIHS01_…` string (or a wildcard for liberal receivers, see
+/// [`super::type_hash`]).
 pub fn topic_keyexpr(domain_id: u16, fq_name: &str, type_name: &str, type_hash: &str) -> String {
   format!(
     "{}/{}/{}/{}",
@@ -120,9 +121,10 @@ pub fn node_liveliness_keyexpr(domain_id: u16, ids: &EntityIds) -> String {
 
 /// Build a publisher / subscription / service liveliness key.
 ///
-/// `qualified_name` is the fully-qualified topic/service name (e.g. `/chatter`);
-/// it is mangled. `qos` is the compact QoS encoding string (opaque here — see
-/// the QoS-encoding work item; callers pass the already-encoded value).
+/// `qualified_name` is the fully-qualified topic/service name (e.g.
+/// `/chatter`); it is mangled. `qos` is the compact QoS encoding string (opaque
+/// here — see the QoS-encoding work item; callers pass the already-encoded
+/// value).
 #[allow(clippy::too_many_arguments)]
 pub fn entity_liveliness_keyexpr(
   domain_id: u16,
@@ -226,7 +228,8 @@ mod tests {
 
   #[test]
   fn subscription_liveliness_key_matches_example() {
-    // @ros2_lv/0/aac.../0/10/MS/%/%/listener/%chatter/std_msgs::msg::dds_::String_/<hash>/::,10:,:,:,,
+    // @ros2_lv/0/aac.../0/10/MS/%/%/listener/%chatter/std_msgs::msg::dds_::String_/
+    // <hash>/::,10:,:,:,,
     let ids = EntityIds {
       session_id: "aac3178e146ba6f1fc6e6a4085e77f21",
       node_id: 0,

--- a/src/zenoh_backend/keyexpr.rs
+++ b/src/zenoh_backend/keyexpr.rs
@@ -159,6 +159,90 @@ pub fn graph_cache_keyexpr(domain_id: u16) -> String {
   format!("{ADMIN_SPACE}/{domain_id}/**")
 }
 
+/// A liveliness token parsed back into its components (the inverse of
+/// [`node_liveliness_keyexpr`] / [`entity_liveliness_keyexpr`]). Names are
+/// demangled (`%`→`/`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParsedEntity {
+  /// ROS domain id.
+  pub domain_id: u16,
+  /// Zenoh session id (hex).
+  pub zid: String,
+  /// Node id within the session.
+  pub node_id: u64,
+  /// Entity id within the node (equals `node_id` for a node token).
+  pub entity_id: u64,
+  /// Entity kind.
+  pub kind: EntityKind,
+  /// Node namespace (demangled), e.g. `/` or `/robot1`.
+  pub namespace: String,
+  /// Node base name.
+  pub node_name: String,
+  /// Topic/service name (demangled), for non-node entities.
+  pub topic_name: Option<String>,
+  /// DDS-form type name, for non-node entities.
+  pub type_name: Option<String>,
+  /// REP-2016 type hash, for non-node entities.
+  pub type_hash: Option<String>,
+  /// Compact QoS string, for non-node entities.
+  pub qos: Option<String>,
+}
+
+fn parse_kind(code: &str) -> Option<EntityKind> {
+  Some(match code {
+    "NN" => EntityKind::Node,
+    "MP" => EntityKind::Publisher,
+    "MS" => EntityKind::Subscription,
+    "SS" => EntityKind::ServiceServer,
+    "SC" => EntityKind::ServiceClient,
+    _ => return None,
+  })
+}
+
+/// Parse a liveliness token key expression into a [`ParsedEntity`], or `None`
+/// if it is not a well-formed `@ros2_lv` token.
+pub fn parse_liveliness_key(key: &str) -> Option<ParsedEntity> {
+  let p: Vec<&str> = key.split('/').collect();
+  if p.first() != Some(&ADMIN_SPACE) || p.len() < 9 {
+    return None;
+  }
+  let domain_id = p[1].parse().ok()?;
+  let zid = p[2].to_owned();
+  let node_id = p[3].parse().ok()?;
+  let entity_id = p[4].parse().ok()?;
+  let kind = parse_kind(p[5])?;
+  let namespace = demangle(p[7]); // p[6] is the enclave (unused here)
+  let node_name = demangle(p[8]);
+
+  let (topic_name, type_name, type_hash, qos) = if kind == EntityKind::Node {
+    (None, None, None, None)
+  } else {
+    if p.len() < 13 {
+      return None;
+    }
+    (
+      Some(demangle(p[9])),
+      Some(p[10].to_owned()),
+      Some(p[11].to_owned()),
+      Some(p[12].to_owned()),
+    )
+  };
+
+  Some(ParsedEntity {
+    domain_id,
+    zid,
+    node_id,
+    entity_id,
+    kind,
+    namespace,
+    node_name,
+    topic_name,
+    type_name,
+    type_hash,
+    qos,
+  })
+}
+
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
@@ -269,5 +353,61 @@ mod tests {
   fn graph_cache_key() {
     assert_eq!(graph_cache_keyexpr(0), "@ros2_lv/0/**");
     assert_eq!(graph_cache_keyexpr(42), "@ros2_lv/42/**");
+  }
+
+  #[test]
+  fn parse_node_token() {
+    let ids = EntityIds {
+      session_id: "aac3178e146ba6f1fc6e6a4085e77f21",
+      node_id: 3,
+      entity_id: 3,
+      enclave: "",
+      namespace: "/robot1",
+      node_name: "talker",
+    };
+    let key = node_liveliness_keyexpr(0, &ids);
+    let e = parse_liveliness_key(&key).expect("parse node token");
+    assert_eq!(e.kind, EntityKind::Node);
+    assert_eq!(e.domain_id, 0);
+    assert_eq!(e.node_id, 3);
+    assert_eq!(e.entity_id, 3);
+    assert_eq!(e.namespace, "/robot1");
+    assert_eq!(e.node_name, "talker");
+    assert_eq!(e.topic_name, None);
+  }
+
+  #[test]
+  fn parse_entity_token_roundtrip() {
+    let ids = EntityIds {
+      session_id: "aac3178e146ba6f1fc6e6a4085e77f21",
+      node_id: 0,
+      entity_id: 10,
+      enclave: "",
+      namespace: "",
+      node_name: "listener",
+    };
+    let key = entity_liveliness_keyexpr(
+      0,
+      &ids,
+      EntityKind::Subscription,
+      "/chatter",
+      "std_msgs::msg::dds_::String_",
+      STRING_HASH,
+      "::,10:,:,:,,",
+    );
+    let e = parse_liveliness_key(&key).expect("parse entity token");
+    assert_eq!(e.kind, EntityKind::Subscription);
+    assert_eq!(e.entity_id, 10);
+    assert_eq!(e.node_name, "listener");
+    assert_eq!(e.topic_name.as_deref(), Some("/chatter"));
+    assert_eq!(e.type_name.as_deref(), Some("std_msgs::msg::dds_::String_"));
+    assert_eq!(e.type_hash.as_deref(), Some(STRING_HASH));
+    assert_eq!(e.qos.as_deref(), Some("::,10:,:,:,,"));
+  }
+
+  #[test]
+  fn parse_rejects_non_tokens() {
+    assert!(parse_liveliness_key("0/chatter/std_msgs::msg::dds_::String_/hash").is_none());
+    assert!(parse_liveliness_key("@ros2_lv/0").is_none());
   }
 }

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -20,6 +20,7 @@
 
 // E2 — backend-neutral wire-format spec (pure; compiled on every build).
 pub(crate) mod gid;
+pub(crate) mod graph_cache;
 pub(crate) mod keyexpr;
 pub(crate) mod qos_encoding;
 pub(crate) mod type_hash;

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -47,6 +47,10 @@ pub(crate) mod pubsub;
 #[cfg(feature = "zenoh")]
 pub(crate) mod service;
 
+// E7 — Actions (services + topics; need the `zenoh` crate).
+#[cfg(feature = "zenoh")]
+pub(crate) mod action;
+
 // E4 — Pub/Sub.
 // #[cfg(feature = "zenoh")]
 // pub(crate) mod pubsub;

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod gid;
 pub(crate) mod graph_cache;
 pub(crate) mod keyexpr;
 pub(crate) mod qos_encoding;
+pub(crate) mod type_description;
 pub(crate) mod type_hash;
 
 // E2 — attachment (de)serialization needs the `zenoh-ext` serializer.

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -35,6 +35,12 @@ pub(crate) mod cdr;
 #[cfg(feature = "zenoh")]
 pub(crate) mod context;
 
+// E4 — Node/Topic and Pub/Sub (need the `zenoh` crate).
+#[cfg(feature = "zenoh")]
+pub(crate) mod node;
+#[cfg(feature = "zenoh")]
+pub(crate) mod pubsub;
+
 // E4 — Pub/Sub.
 // #[cfg(feature = "zenoh")]
 // pub(crate) mod pubsub;

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -24,8 +24,8 @@ pub(crate) mod keyexpr;
 pub(crate) mod type_hash;
 
 // E2 — attachment (de)serialization needs the `zenoh-ext` serializer.
-// #[cfg(feature = "zenoh")]
-// pub(crate) mod attachment;
+#[cfg(feature = "zenoh")]
+pub(crate) mod attachment;
 
 // E3 — Zenoh session / Context (needs the `zenoh` crate).
 #[cfg(feature = "zenoh")]

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -27,9 +27,9 @@ pub(crate) mod type_hash;
 // #[cfg(feature = "zenoh")]
 // pub(crate) mod attachment;
 
-// E3 — Zenoh session / Context.
-// #[cfg(feature = "zenoh")]
-// pub(crate) mod session;
+// E3 — Zenoh session / Context (needs the `zenoh` crate).
+#[cfg(feature = "zenoh")]
+pub(crate) mod context;
 
 // E4 — Pub/Sub.
 // #[cfg(feature = "zenoh")]

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -21,6 +21,7 @@
 // E2 — backend-neutral wire-format spec (pure; compiled on every build).
 pub(crate) mod gid;
 pub(crate) mod keyexpr;
+pub(crate) mod qos_encoding;
 pub(crate) mod type_hash;
 
 // E2 — attachment (de)serialization needs the `zenoh-ext` serializer.

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -43,6 +43,10 @@ pub(crate) mod node;
 #[cfg(feature = "zenoh")]
 pub(crate) mod pubsub;
 
+// E6 — Services over queryable/get (need the `zenoh` crate).
+#[cfg(feature = "zenoh")]
+pub(crate) mod service;
+
 // E4 — Pub/Sub.
 // #[cfg(feature = "zenoh")]
 // pub(crate) mod pubsub;

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -51,6 +51,10 @@ pub(crate) mod service;
 #[cfg(feature = "zenoh")]
 pub(crate) mod action;
 
+// E8 — Parameters (six services + `parameter_events` topic; need `zenoh`).
+#[cfg(feature = "zenoh")]
+pub(crate) mod parameters;
+
 // E4 — Pub/Sub.
 // #[cfg(feature = "zenoh")]
 // pub(crate) mod pubsub;

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -27,6 +27,10 @@ pub(crate) mod type_hash;
 #[cfg(feature = "zenoh")]
 pub(crate) mod attachment;
 
+// E2/E4 — CDR message (de)serialization needs `cdr-encoding`.
+#[cfg(feature = "zenoh")]
+pub(crate) mod cdr;
+
 // E3 — Zenoh session / Context (needs the `zenoh` crate).
 #[cfg(feature = "zenoh")]
 pub(crate) mod context;

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -12,10 +12,10 @@
 //! The submodules are populated by the E2–E6 work items (see
 //! `docs/zenoh_study/refactoring_plan.md`).
 //!
-//! The "wire-format spec" submodules below ([`keyexpr`], [`type_hash`], [`gid`])
-//! are pure (no dependency on the `zenoh` crate), so they compile and are
-//! unit-tested on any build — including the default `dds` build, where they are
-//! otherwise unused.
+//! The "wire-format spec" submodules below ([`keyexpr`], [`type_hash`],
+//! [`gid`]) are pure (no dependency on the `zenoh` crate), so they compile and
+//! are unit-tested on any build — including the default `dds` build, where they
+//! are otherwise unused.
 #![allow(dead_code)] // spec modules are unused on the `dds` build
 
 // E2 — backend-neutral wire-format spec (pure; compiled on every build).

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -55,6 +55,10 @@ pub(crate) mod action;
 #[cfg(feature = "zenoh")]
 pub(crate) mod parameters;
 
+// E9 — rosout logging (`/rosout` topic; needs the `zenoh` crate).
+#[cfg(feature = "zenoh")]
+pub(crate) mod rosout;
+
 // E4 — Pub/Sub.
 // #[cfg(feature = "zenoh")]
 // pub(crate) mod pubsub;

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -10,25 +10,35 @@
 //! - GID → XXH3-128 of the entity's liveliness key
 //!
 //! The submodules are populated by the E2–E6 work items (see
-//! `docs/zenoh_study/refactoring_plan.md`). They are declared here as they land
-//! so the backend grows behind a single `#[cfg(feature = "zenoh")]` boundary.
+//! `docs/zenoh_study/refactoring_plan.md`).
+//!
+//! The "wire-format spec" submodules below ([`keyexpr`], [`type_hash`], [`gid`])
+//! are pure (no dependency on the `zenoh` crate), so they compile and are
+//! unit-tested on any build — including the default `dds` build, where they are
+//! otherwise unused.
+#![allow(dead_code)] // spec modules are unused on the `dds` build
 
-// E2 — Zenoh wire primitives (keyexpr / attachment / type-hash / gid / CDR).
-// pub(crate) mod keyexpr;
+// E2 — backend-neutral wire-format spec (pure; compiled on every build).
+pub(crate) mod gid;
+pub(crate) mod keyexpr;
+pub(crate) mod type_hash;
+
+// E2 — attachment (de)serialization needs the `zenoh-ext` serializer.
+// #[cfg(feature = "zenoh")]
 // pub(crate) mod attachment;
-// pub(crate) mod type_hash;
-// pub(crate) mod gid;
-// pub(crate) mod cdr;
 
 // E3 — Zenoh session / Context.
+// #[cfg(feature = "zenoh")]
 // pub(crate) mod session;
 
 // E4 — Pub/Sub.
+// #[cfg(feature = "zenoh")]
 // pub(crate) mod pubsub;
 
 // E5 — Discovery: liveliness tokens + graph cache.
-// pub(crate) mod liveliness;
+// #[cfg(feature = "zenoh")]
 // pub(crate) mod graph_cache;
 
 // E6 — Services over queryable / get.
+// #[cfg(feature = "zenoh")]
 // pub(crate) mod service;

--- a/src/zenoh_backend/mod.rs
+++ b/src/zenoh_backend/mod.rs
@@ -1,0 +1,34 @@
+//! Zenoh middleware backend for `ros2-client` (cargo feature `zenoh`).
+//!
+//! This module tree implements the ROS 2 ↔ Zenoh mapping described in
+//! `docs/zenoh_study/` and mirrors the official `rmw_zenoh` design:
+//!
+//! - topics → key expressions `<domain>/<name>/<type>/<type_hash>`
+//! - discovery → liveliness tokens under `@ros2_lv/<domain>/**` + a graph cache
+//! - every message carries an attachment `(seq, source_timestamp, source_gid)`
+//! - services → Zenoh queryable / get
+//! - GID → XXH3-128 of the entity's liveliness key
+//!
+//! The submodules are populated by the E2–E6 work items (see
+//! `docs/zenoh_study/refactoring_plan.md`). They are declared here as they land
+//! so the backend grows behind a single `#[cfg(feature = "zenoh")]` boundary.
+
+// E2 — Zenoh wire primitives (keyexpr / attachment / type-hash / gid / CDR).
+// pub(crate) mod keyexpr;
+// pub(crate) mod attachment;
+// pub(crate) mod type_hash;
+// pub(crate) mod gid;
+// pub(crate) mod cdr;
+
+// E3 — Zenoh session / Context.
+// pub(crate) mod session;
+
+// E4 — Pub/Sub.
+// pub(crate) mod pubsub;
+
+// E5 — Discovery: liveliness tokens + graph cache.
+// pub(crate) mod liveliness;
+// pub(crate) mod graph_cache;
+
+// E6 — Services over queryable / get.
+// pub(crate) mod service;

--- a/src/zenoh_backend/node.rs
+++ b/src/zenoh_backend/node.rs
@@ -23,6 +23,7 @@ use super::{
   parameters::{ParameterClient, ParameterEvent, ParameterServer},
   pubsub::{Publisher, Subscription},
   qos_encoding,
+  rosout::{Log, Logger},
   service::{Client, Server},
   type_hash,
 };
@@ -471,6 +472,31 @@ impl Node {
       set_parameters,
       list_parameters,
       describe_parameters,
+    ))
+  }
+
+  /// Create a rosout [`Logger`] for this node: a publisher on the global
+  /// `/rosout` topic (`rcl_interfaces/msg/Log`). Records are stamped with this
+  /// node's base name. Use the [`rosout!`](crate::rosout!) macro to log.
+  pub fn create_logger(&self) -> zenoh::Result<Logger> {
+    let publisher = self.create_publisher::<Log>(&self.rosout_topic()?, None)?;
+    Ok(Logger::new(
+      self.node_name.base_name().to_string(),
+      publisher,
+    ))
+  }
+
+  /// Subscribe to the global `/rosout` topic to read log records published by
+  /// any node (the `read_rosout` capability).
+  pub fn read_rosout(&self) -> zenoh::Result<Subscription<Log>> {
+    self.create_subscription::<Log>(&self.rosout_topic()?, None)
+  }
+
+  fn rosout_topic(&self) -> zenoh::Result<Topic> {
+    Ok(self.create_topic(
+      &Name::new("/", "rosout").map_err(name_err)?,
+      MessageTypeName::new("rcl_interfaces", "Log"),
+      &QosProfile::default(),
     ))
   }
 }

--- a/src/zenoh_backend/node.rs
+++ b/src/zenoh_backend/node.rs
@@ -499,6 +499,18 @@ impl Node {
       &QosProfile::default(),
     ))
   }
+
+  /// Resolve once at least one publisher on `topic` is discovered (delegates to
+  /// [`Context::wait_for_publisher`](crate::Context::wait_for_publisher)).
+  pub async fn wait_for_publisher(&self, topic: &str) {
+    self.context.wait_for_publisher(topic).await
+  }
+
+  /// Resolve once at least one subscription on `topic` is discovered (delegates
+  /// to [`Context::wait_for_subscription`](crate::Context::wait_for_subscription)).
+  pub async fn wait_for_subscription(&self, topic: &str) {
+    self.context.wait_for_subscription(topic).await
+  }
 }
 
 /// Build the absolute `Name` of a parameter service, e.g.

--- a/src/zenoh_backend/node.rs
+++ b/src/zenoh_backend/node.rs
@@ -14,10 +14,12 @@ use super::{
   context::Context,
   gid, keyexpr,
   pubsub::{Publisher, Subscription},
-  qos_encoding, type_hash,
+  qos_encoding,
+  service::{Client, Server},
+  type_hash,
 };
 use crate::{
-  names::{MessageTypeName, Name, NodeName},
+  names::{MessageTypeName, Name, NodeName, ServiceTypeName},
   qos::QosProfile,
 };
 
@@ -187,13 +189,33 @@ impl Node {
     Ok(Subscription::new(zenoh_subscriber, token))
   }
 
-  /// Build the liveliness key for an entity of this node, including the compact
-  /// QoS encoding.
+  /// Build the liveliness key for a pub/sub entity of this node.
   fn entity_liveliness_key(
     &self,
     entity_id: u64,
     kind: keyexpr::EntityKind,
     topic: &Topic,
+    hash: &str,
+    qos: &QosProfile,
+  ) -> String {
+    self.liveliness_key(
+      entity_id,
+      kind,
+      &topic.fully_qualified_name,
+      &topic.dds_type_name,
+      hash,
+      qos,
+    )
+  }
+
+  /// Build the liveliness key for any entity of this node, including the
+  /// compact QoS encoding.
+  fn liveliness_key(
+    &self,
+    entity_id: u64,
+    kind: keyexpr::EntityKind,
+    fqn: &str,
+    dds_type: &str,
     hash: &str,
     qos: &QosProfile,
   ) -> String {
@@ -209,11 +231,80 @@ impl Node {
       self.context.domain_id(),
       &ids,
       kind,
-      &topic.fully_qualified_name,
-      &topic.dds_type_name,
+      fqn,
+      dds_type,
       hash,
       &qos_encoding::encode_qos(qos),
     )
+  }
+
+  /// Create a service client for `service` of the given service type.
+  pub fn create_client<Req: serde::Serialize, Resp: DeserializeOwned>(
+    &self,
+    service: &Name,
+    service_type: &ServiceTypeName,
+  ) -> zenoh::Result<Client<Req, Resp>> {
+    let fqn = resolve_fqn(service, &self.node_name);
+    let dds_type = service_type.dds_service_type();
+    let domain = self.context.domain_id();
+    // The client `get`s on the concrete service key (real hash if known, else
+    // placeholder) so it matches the server's concrete queryable. A `get`
+    // selector must match the queryable's key; for known interop types this is
+    // the real RIHS01 hash and so also matches C++ servers.
+    let hash = type_hash::sender_hash(&dds_type);
+    let selector = keyexpr::topic_keyexpr(domain, &fqn, &dds_type, hash);
+
+    let entity_id = self.next_entity_id.fetch_add(1, Ordering::Relaxed);
+    let liveliness_key = self.liveliness_key(
+      entity_id,
+      keyexpr::EntityKind::ServiceClient,
+      &fqn,
+      &dds_type,
+      hash,
+      &QosProfile::default(),
+    );
+    let client_gid = gid::gid_from_liveliness_key(&liveliness_key);
+    let token = declare_liveliness(&self.context, liveliness_key);
+
+    Ok(Client::new(
+      self.context.session().clone(),
+      selector,
+      client_gid,
+      token,
+    ))
+  }
+
+  /// Create a service server for `service` of the given service type.
+  pub fn create_server<Req: DeserializeOwned, Resp: serde::Serialize>(
+    &self,
+    service: &Name,
+    service_type: &ServiceTypeName,
+  ) -> zenoh::Result<Server<Req, Resp>> {
+    let fqn = resolve_fqn(service, &self.node_name);
+    let dds_type = service_type.dds_service_type();
+    let domain = self.context.domain_id();
+    let hash = type_hash::sender_hash(&dds_type);
+    // The server's queryable is concrete (real-or-placeholder hash).
+    let key = keyexpr::topic_keyexpr(domain, &fqn, &dds_type, hash);
+    let queryable = self
+      .context
+      .session()
+      .declare_queryable(key)
+      .complete(true)
+      .wait()?;
+
+    let entity_id = self.next_entity_id.fetch_add(1, Ordering::Relaxed);
+    let liveliness_key = self.liveliness_key(
+      entity_id,
+      keyexpr::EntityKind::ServiceServer,
+      &fqn,
+      &dds_type,
+      hash,
+      &QosProfile::default(),
+    );
+    let token = declare_liveliness(&self.context, liveliness_key);
+
+    Ok(Server::new(queryable, token))
   }
 }
 

--- a/src/zenoh_backend/node.rs
+++ b/src/zenoh_backend/node.rs
@@ -28,6 +28,7 @@ use super::{
   type_hash,
 };
 use crate::{
+  action_msgs::{CancelGoalRequest, CancelGoalResponse, GoalStatusArray},
   names::{ActionTypeName, MessageTypeName, Name, NodeName, ServiceTypeName},
   parameters::Parameter,
   qos::QosProfile,
@@ -359,7 +360,25 @@ impl Node {
       &QosProfile::default(),
     );
     let feedback = self.create_subscription::<FeedbackMessage<F>>(&feedback_topic, None)?;
-    Ok(ActionClient::new(send_goal, get_result, feedback))
+    // cancel_goal + status use the shared `action_msgs` types (not
+    // action-namespaced), matching rmw_zenoh / the DDS backend.
+    let cancel_goal = self.create_client::<CancelGoalRequest, CancelGoalResponse>(
+      &action_sub_name(&fqn, "cancel_goal")?,
+      &ServiceTypeName::new("action_msgs", "CancelGoal"),
+    )?;
+    let status_topic = self.create_topic(
+      &action_sub_name(&fqn, "status")?,
+      MessageTypeName::new("action_msgs", "GoalStatusArray"),
+      &QosProfile::default(),
+    );
+    let status = self.create_subscription::<GoalStatusArray>(&status_topic, None)?;
+    Ok(ActionClient::new(
+      send_goal,
+      get_result,
+      feedback,
+      cancel_goal,
+      status,
+    ))
   }
 
   /// Create an action server for `action` of the given action type.
@@ -388,7 +407,23 @@ impl Node {
       &QosProfile::default(),
     );
     let feedback = self.create_publisher::<FeedbackMessage<F>>(&feedback_topic, None)?;
-    Ok(ActionServer::new(send_goal, get_result, feedback))
+    let cancel_goal = self.create_server::<CancelGoalRequest, CancelGoalResponse>(
+      &action_sub_name(&fqn, "cancel_goal")?,
+      &ServiceTypeName::new("action_msgs", "CancelGoal"),
+    )?;
+    let status_topic = self.create_topic(
+      &action_sub_name(&fqn, "status")?,
+      MessageTypeName::new("action_msgs", "GoalStatusArray"),
+      &QosProfile::default(),
+    );
+    let status = self.create_publisher::<GoalStatusArray>(&status_topic, None)?;
+    Ok(ActionServer::new(
+      send_goal,
+      get_result,
+      feedback,
+      cancel_goal,
+      status,
+    ))
   }
 
   /// Create a [`ParameterServer`] for this node: the six `rcl_interfaces`

--- a/src/zenoh_backend/node.rs
+++ b/src/zenoh_backend/node.rs
@@ -8,13 +8,13 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::{de::DeserializeOwned, Serialize};
-use zenoh::Wait;
+use zenoh::{liveliness::LivelinessToken, Wait};
 
 use super::{
   context::Context,
   gid, keyexpr,
   pubsub::{Publisher, Subscription},
-  type_hash,
+  qos_encoding, type_hash,
 };
 use crate::{
   names::{MessageTypeName, Name, NodeName},
@@ -68,6 +68,8 @@ pub struct Node {
   node_id: u64,
   zid: String,
   next_entity_id: AtomicU64,
+  // Kept alive so the node stays discoverable; dropped => token undeclared.
+  _node_token: Option<LivelinessToken>,
 }
 
 impl Node {
@@ -78,12 +80,24 @@ impl Node {
     _options: NodeOptions,
   ) -> Self {
     let zid = context.session().zid().to_string();
+    // Declare the node (NN) liveliness token so peers discover this node.
+    let ids = keyexpr::EntityIds {
+      session_id: &zid,
+      node_id,
+      entity_id: node_id,
+      enclave: "",
+      namespace: node_name.namespace(),
+      node_name: node_name.base_name(),
+    };
+    let node_key = keyexpr::node_liveliness_keyexpr(context.domain_id(), &ids);
+    let node_token = declare_liveliness(&context, node_key);
     Self {
       context,
       node_name,
       node_id,
       zid,
       next_entity_id: AtomicU64::new(0),
+      _node_token: node_token,
     }
   }
 
@@ -113,7 +127,7 @@ impl Node {
     topic: &Topic,
     qos: Option<QosProfile>,
   ) -> zenoh::Result<Publisher<M>> {
-    let _qos = qos.unwrap_or_else(|| topic.qos.clone());
+    let qos = qos.unwrap_or_else(|| topic.qos.clone());
     let domain = self.context.domain_id();
     let sender_hash = type_hash::sender_hash(&topic.dds_type_name);
     // A publisher `put`s on a concrete key (real hash if known, else placeholder).
@@ -124,14 +138,19 @@ impl Node {
       sender_hash,
     );
     let zenoh_publisher = self.context.session().declare_publisher(key).wait()?;
+
     let entity_id = self.next_entity_id.fetch_add(1, Ordering::Relaxed);
-    let source_gid = self.entity_gid(
+    let liveliness_key = self.entity_liveliness_key(
       entity_id,
       keyexpr::EntityKind::Publisher,
       topic,
       sender_hash,
+      &qos,
     );
-    Ok(Publisher::new(zenoh_publisher, source_gid))
+    let source_gid = gid::gid_from_liveliness_key(&liveliness_key);
+    let token = declare_liveliness(&self.context, liveliness_key);
+
+    Ok(Publisher::new(zenoh_publisher, source_gid, token))
   }
 
   /// Create a subscription for `topic`. `qos` overrides the topic QoS if given.
@@ -140,7 +159,7 @@ impl Node {
     topic: &Topic,
     qos: Option<QosProfile>,
   ) -> zenoh::Result<Subscription<M>> {
-    let _qos = qos.unwrap_or_else(|| topic.qos.clone());
+    let qos = qos.unwrap_or_else(|| topic.qos.clone());
     let domain = self.context.domain_id();
     // A subscription listens with a wildcard type-hash to receive from any
     // publisher regardless of its hash (liberal receive, ADR-0007).
@@ -151,19 +170,33 @@ impl Node {
       type_hash::WILDCARD,
     );
     let zenoh_subscriber = self.context.session().declare_subscriber(key).wait()?;
-    let _entity_id = self.next_entity_id.fetch_add(1, Ordering::Relaxed);
-    Ok(Subscription::new(zenoh_subscriber))
+
+    // The liveliness token, unlike the data key, is concrete (real-or-placeholder
+    // hash) — it describes this entity for discovery.
+    let entity_id = self.next_entity_id.fetch_add(1, Ordering::Relaxed);
+    let sub_hash = type_hash::sender_hash(&topic.dds_type_name);
+    let liveliness_key = self.entity_liveliness_key(
+      entity_id,
+      keyexpr::EntityKind::Subscription,
+      topic,
+      sub_hash,
+      &qos,
+    );
+    let token = declare_liveliness(&self.context, liveliness_key);
+
+    Ok(Subscription::new(zenoh_subscriber, token))
   }
 
-  /// Compute the 16-byte GID of an entity from its liveliness key. The compact
-  /// QoS component is empty for now; E5 fills it in once QoS encoding lands.
-  fn entity_gid(
+  /// Build the liveliness key for an entity of this node, including the compact
+  /// QoS encoding.
+  fn entity_liveliness_key(
     &self,
     entity_id: u64,
     kind: keyexpr::EntityKind,
     topic: &Topic,
     hash: &str,
-  ) -> [u8; 16] {
+    qos: &QosProfile,
+  ) -> String {
     let ids = keyexpr::EntityIds {
       session_id: &self.zid,
       node_id: self.node_id,
@@ -172,16 +205,32 @@ impl Node {
       namespace: self.node_name.namespace(),
       node_name: self.node_name.base_name(),
     };
-    let liveliness_key = keyexpr::entity_liveliness_keyexpr(
+    keyexpr::entity_liveliness_keyexpr(
       self.context.domain_id(),
       &ids,
       kind,
       &topic.fully_qualified_name,
       &topic.dds_type_name,
       hash,
-      "",
-    );
-    gid::gid_from_liveliness_key(&liveliness_key)
+      &qos_encoding::encode_qos(qos),
+    )
+  }
+}
+
+/// Declare a liveliness token on `key`, best-effort: a failure logs a warning
+/// and returns `None` (the entity still works; it just isn't discoverable).
+fn declare_liveliness(context: &Context, key: String) -> Option<LivelinessToken> {
+  match context
+    .session()
+    .liveliness()
+    .declare_token(key.clone())
+    .wait()
+  {
+    Ok(token) => Some(token),
+    Err(e) => {
+      log::warn!("failed to declare liveliness token for {key}: {e}");
+      None
+    }
   }
 }
 
@@ -205,7 +254,15 @@ fn resolve_fqn(name: &Name, node: &NodeName) -> String {
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+  use std::time::{Duration, Instant};
+
+  use zenoh::{Config, Wait};
+
+  use super::{
+    keyexpr::{graph_cache_keyexpr, parse_liveliness_key, EntityKind},
+    *,
+  };
+  use crate::{Context, ContextOptions};
 
   #[test]
   fn fqn_resolution() {
@@ -218,5 +275,78 @@ mod tests {
 
     let abs = Name::new("/", "chatter").unwrap();
     assert_eq!(resolve_fqn(&abs, &node), "/chatter");
+  }
+
+  fn make_config(listen_port: u16, connect_port: Option<u16>) -> Config {
+    let mut c = Config::default();
+    c.insert_json5("mode", "\"peer\"").unwrap();
+    c.insert_json5("scouting/multicast/enabled", "false")
+      .unwrap();
+    c.insert_json5(
+      "listen/endpoints",
+      &format!("[\"tcp/127.0.0.1:{listen_port}\"]"),
+    )
+    .unwrap();
+    if let Some(p) = connect_port {
+      c.insert_json5("connect/endpoints", &format!("[\"tcp/127.0.0.1:{p}\"]"))
+        .unwrap();
+    }
+    c
+  }
+
+  // A publisher created on one context is discovered by another via its
+  // liveliness tokens (node NN + publisher MP), parsed back correctly.
+  #[test]
+  fn discovers_entities_via_liveliness() {
+    let a_port = 17515;
+    let b_port = 17516;
+
+    let ctx_a =
+      Context::with_options(ContextOptions::new().zenoh_config(make_config(a_port, None))).unwrap();
+    let ctx_b =
+      Context::with_options(ContextOptions::new().zenoh_config(make_config(b_port, Some(a_port))))
+        .unwrap();
+
+    let node_a = ctx_a.new_node(NodeName::new("/", "talker").unwrap(), NodeOptions::new());
+    let topic = node_a.create_topic(
+      &Name::new("/", "chatter").unwrap(),
+      MessageTypeName::new("std_msgs", "String"),
+      &QosProfile::publisher_default(),
+    );
+    let _publisher: Publisher<String> = node_a.create_publisher(&topic, None).unwrap();
+
+    let graph_key = graph_cache_keyexpr(ctx_b.domain_id());
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut saw_node = false;
+    let mut saw_publisher = false;
+
+    while Instant::now() < deadline && !(saw_node && saw_publisher) {
+      let replies = ctx_b.session().liveliness().get(&graph_key).wait().unwrap();
+      while let Ok(reply) = replies.recv() {
+        if let Ok(sample) = reply.result() {
+          if let Some(e) = parse_liveliness_key(sample.key_expr().as_str()) {
+            match e.kind {
+              EntityKind::Node if e.node_name == "talker" => saw_node = true,
+              EntityKind::Publisher
+                if e.topic_name.as_deref() == Some("/chatter") && e.node_name == "talker" =>
+              {
+                saw_publisher = true
+              }
+              _ => {}
+            }
+          }
+        }
+      }
+      if saw_node && saw_publisher {
+        break;
+      }
+      std::thread::sleep(Duration::from_millis(100));
+    }
+
+    assert!(saw_node, "did not discover the talker node token");
+    assert!(
+      saw_publisher,
+      "did not discover the /chatter publisher token"
+    );
   }
 }

--- a/src/zenoh_backend/node.rs
+++ b/src/zenoh_backend/node.rs
@@ -5,12 +5,19 @@
 //! entities. Discovery (liveliness tokens, graph), services, and actions land
 //! in E5/E6.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+  sync::atomic::{AtomicU64, Ordering},
+  time::Duration,
+};
 
 use serde::{de::DeserializeOwned, Serialize};
 use zenoh::{liveliness::LivelinessToken, Wait};
 
 use super::{
+  action::{
+    ActionClient, ActionServer, FeedbackMessage, GetResultRequest, GetResultResponse,
+    SendGoalRequest, SendGoalResponse,
+  },
   context::Context,
   gid, keyexpr,
   pubsub::{Publisher, Subscription},
@@ -19,9 +26,14 @@ use super::{
   type_hash,
 };
 use crate::{
-  names::{MessageTypeName, Name, NodeName, ServiceTypeName},
+  names::{ActionTypeName, MessageTypeName, Name, NodeName, ServiceTypeName},
   qos::QosProfile,
 };
+
+/// The `get_result` action service is queried with a long timeout, mirroring
+/// rmw_zenoh's `**/_action/get_result/**` heuristic (a goal may take a long
+/// time to finish). Bounded to avoid indefinite hangs; production may raise it.
+const GET_RESULT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Options for creating a [`Node`] on the Zenoh backend.
 ///
@@ -244,6 +256,15 @@ impl Node {
     service: &Name,
     service_type: &ServiceTypeName,
   ) -> zenoh::Result<Client<Req, Resp>> {
+    self.create_client_inner(service, service_type, None)
+  }
+
+  fn create_client_inner<Req: serde::Serialize, Resp: DeserializeOwned>(
+    &self,
+    service: &Name,
+    service_type: &ServiceTypeName,
+    timeout: Option<Duration>,
+  ) -> zenoh::Result<Client<Req, Resp>> {
     let fqn = resolve_fqn(service, &self.node_name);
     let dds_type = service_type.dds_service_type();
     let domain = self.context.domain_id();
@@ -266,11 +287,12 @@ impl Node {
     let client_gid = gid::gid_from_liveliness_key(&liveliness_key);
     let token = declare_liveliness(&self.context, liveliness_key);
 
-    Ok(Client::new(
+    Ok(Client::new_with_timeout(
       self.context.session().clone(),
       selector,
       client_gid,
       token,
+      timeout,
     ))
   }
 
@@ -306,6 +328,71 @@ impl Node {
 
     Ok(Server::new(queryable, token))
   }
+
+  /// Create an action client for `action` of the given action type.
+  pub fn create_action_client<G, R, F>(
+    &self,
+    action: &Name,
+    action_type: &ActionTypeName,
+  ) -> zenoh::Result<ActionClient<G, R, F>>
+  where
+    G: Serialize,
+    R: DeserializeOwned,
+    F: DeserializeOwned,
+  {
+    let fqn = resolve_fqn(action, &self.node_name);
+    let send_goal = self.create_client::<SendGoalRequest<G>, SendGoalResponse>(
+      &action_sub_name(&fqn, "send_goal")?,
+      &action_type.dds_action_service("_SendGoal"),
+    )?;
+    let get_result = self.create_client_inner::<GetResultRequest, GetResultResponse<R>>(
+      &action_sub_name(&fqn, "get_result")?,
+      &action_type.dds_action_service("_GetResult"),
+      Some(GET_RESULT_TIMEOUT),
+    )?;
+    let feedback_topic = self.create_topic(
+      &action_sub_name(&fqn, "feedback")?,
+      action_type.dds_action_topic("_FeedbackMessage"),
+      &QosProfile::default(),
+    );
+    let feedback = self.create_subscription::<FeedbackMessage<F>>(&feedback_topic, None)?;
+    Ok(ActionClient::new(send_goal, get_result, feedback))
+  }
+
+  /// Create an action server for `action` of the given action type.
+  pub fn create_action_server<G, R, F>(
+    &self,
+    action: &Name,
+    action_type: &ActionTypeName,
+  ) -> zenoh::Result<ActionServer<G, R, F>>
+  where
+    G: DeserializeOwned,
+    R: Serialize,
+    F: Serialize,
+  {
+    let fqn = resolve_fqn(action, &self.node_name);
+    let send_goal = self.create_server::<SendGoalRequest<G>, SendGoalResponse>(
+      &action_sub_name(&fqn, "send_goal")?,
+      &action_type.dds_action_service("_SendGoal"),
+    )?;
+    let get_result = self.create_server::<GetResultRequest, GetResultResponse<R>>(
+      &action_sub_name(&fqn, "get_result")?,
+      &action_type.dds_action_service("_GetResult"),
+    )?;
+    let feedback_topic = self.create_topic(
+      &action_sub_name(&fqn, "feedback")?,
+      action_type.dds_action_topic("_FeedbackMessage"),
+      &QosProfile::default(),
+    );
+    let feedback = self.create_publisher::<FeedbackMessage<F>>(&feedback_topic, None)?;
+    Ok(ActionServer::new(send_goal, get_result, feedback))
+  }
+}
+
+/// Build the absolute `Name` of an action sub-entity, e.g.
+/// `/fibonacci` + `send_goal` → `/fibonacci/_action/send_goal`.
+fn action_sub_name(action_fqn: &str, sub: &str) -> zenoh::Result<Name> {
+  Name::new(&format!("{action_fqn}/_action"), sub).map_err(|e| -> zenoh::Error { Box::new(e) })
 }
 
 /// Declare a liveliness token on `key`, best-effort: a failure logs a warning

--- a/src/zenoh_backend/node.rs
+++ b/src/zenoh_backend/node.rs
@@ -20,6 +20,7 @@ use super::{
   },
   context::Context,
   gid, keyexpr,
+  parameters::{ParameterClient, ParameterEvent, ParameterServer},
   pubsub::{Publisher, Subscription},
   qos_encoding,
   service::{Client, Server},
@@ -27,6 +28,7 @@ use super::{
 };
 use crate::{
   names::{ActionTypeName, MessageTypeName, Name, NodeName, ServiceTypeName},
+  parameters::Parameter,
   qos::QosProfile,
 };
 
@@ -387,6 +389,100 @@ impl Node {
     let feedback = self.create_publisher::<FeedbackMessage<F>>(&feedback_topic, None)?;
     Ok(ActionServer::new(send_goal, get_result, feedback))
   }
+
+  /// Create a [`ParameterServer`] for this node: the six `rcl_interfaces`
+  /// parameter services (named under this node, e.g.
+  /// `/talker/get_parameters`) plus the global `/parameter_events` publisher.
+  ///
+  /// `initial_parameters` seeds the parameter store (`use_sim_time` is always
+  /// added). Drive the returned server with
+  /// [`ParameterServer::spin_once`]/[`spin`](ParameterServer::spin).
+  pub fn create_parameter_server(
+    &self,
+    initial_parameters: impl IntoIterator<Item = Parameter>,
+  ) -> zenoh::Result<ParameterServer> {
+    let node_fqn = self.node_name.fully_qualified_name();
+    let svc = |base: &str| param_service_name(&node_fqn, base);
+    let param_type = |ty: &str| ServiceTypeName::new("rcl_interfaces", ty);
+
+    let get_parameters =
+      self.create_server(&svc("get_parameters")?, &param_type("GetParameters"))?;
+    let get_parameter_types = self.create_server(
+      &svc("get_parameter_types")?,
+      &param_type("GetParameterTypes"),
+    )?;
+    let set_parameters =
+      self.create_server(&svc("set_parameters")?, &param_type("SetParameters"))?;
+    let set_parameters_atomically = self.create_server(
+      &svc("set_parameters_atomically")?,
+      &param_type("SetParametersAtomically"),
+    )?;
+    let list_parameters =
+      self.create_server(&svc("list_parameters")?, &param_type("ListParameters"))?;
+    let describe_parameters = self.create_server(
+      &svc("describe_parameters")?,
+      &param_type("DescribeParameters"),
+    )?;
+
+    let events_topic = self.create_topic(
+      &Name::new("/", "parameter_events").map_err(name_err)?,
+      MessageTypeName::new("rcl_interfaces", "ParameterEvent"),
+      &QosProfile::default(),
+    );
+    let events = self.create_publisher::<ParameterEvent>(&events_topic, None)?;
+
+    Ok(ParameterServer::new(
+      node_fqn,
+      initial_parameters,
+      get_parameters,
+      get_parameter_types,
+      set_parameters,
+      set_parameters_atomically,
+      list_parameters,
+      describe_parameters,
+      events,
+    ))
+  }
+
+  /// Create a [`ParameterClient`] targeting `remote_node`'s parameter services.
+  pub fn create_parameter_client(&self, remote_node: &NodeName) -> zenoh::Result<ParameterClient> {
+    let remote_fqn = remote_node.fully_qualified_name();
+    let svc = |base: &str| param_service_name(&remote_fqn, base);
+    let param_type = |ty: &str| ServiceTypeName::new("rcl_interfaces", ty);
+
+    let get_parameters =
+      self.create_client(&svc("get_parameters")?, &param_type("GetParameters"))?;
+    let get_parameter_types = self.create_client(
+      &svc("get_parameter_types")?,
+      &param_type("GetParameterTypes"),
+    )?;
+    let set_parameters =
+      self.create_client(&svc("set_parameters")?, &param_type("SetParameters"))?;
+    let list_parameters =
+      self.create_client(&svc("list_parameters")?, &param_type("ListParameters"))?;
+    let describe_parameters = self.create_client(
+      &svc("describe_parameters")?,
+      &param_type("DescribeParameters"),
+    )?;
+
+    Ok(ParameterClient::new(
+      get_parameters,
+      get_parameter_types,
+      set_parameters,
+      list_parameters,
+      describe_parameters,
+    ))
+  }
+}
+
+/// Build the absolute `Name` of a parameter service, e.g.
+/// node fqn `/talker` + `get_parameters` → `/talker/get_parameters`.
+fn param_service_name(node_fqn: &str, base: &str) -> zenoh::Result<Name> {
+  Name::new(node_fqn, base).map_err(name_err)
+}
+
+fn name_err(e: crate::names::NameError) -> zenoh::Error {
+  Box::new(e)
 }
 
 /// Build the absolute `Name` of an action sub-entity, e.g.

--- a/src/zenoh_backend/node.rs
+++ b/src/zenoh_backend/node.rs
@@ -1,0 +1,222 @@
+//! Zenoh `Node` and `Topic` (E4).
+//!
+//! A minimal node surface over a shared [`Context`] session: it resolves ROS
+//! names to key expressions and creates [`Publisher`]/[`Subscription`]
+//! entities. Discovery (liveliness tokens, graph), services, and actions land
+//! in E5/E6.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{de::DeserializeOwned, Serialize};
+use zenoh::Wait;
+
+use super::{
+  context::Context,
+  gid, keyexpr,
+  pubsub::{Publisher, Subscription},
+  type_hash,
+};
+use crate::{
+  names::{MessageTypeName, Name, NodeName},
+  qos::QosProfile,
+};
+
+/// Options for creating a [`Node`] on the Zenoh backend.
+///
+/// Currently a placeholder (parity with the DDS `NodeOptions`);
+/// rosout/parameter toggles arrive with E8/E9.
+#[derive(Clone, Debug, Default)]
+pub struct NodeOptions {}
+
+impl NodeOptions {
+  /// Default node options.
+  pub fn new() -> Self {
+    Self {}
+  }
+}
+
+/// A handle to a ROS 2 topic: its fully-qualified name, DDS-form type name, and
+/// QoS. Produced by [`Node::create_topic`].
+#[derive(Clone, Debug)]
+pub struct Topic {
+  fully_qualified_name: String,
+  dds_type_name: String,
+  qos: QosProfile,
+}
+
+impl Topic {
+  /// The fully-qualified ROS topic name (e.g. `/chatter`).
+  pub fn name(&self) -> &str {
+    &self.fully_qualified_name
+  }
+
+  /// The DDS-form type name (e.g. `std_msgs::msg::dds_::String_`).
+  pub fn type_name(&self) -> &str {
+    &self.dds_type_name
+  }
+
+  /// The topic's QoS profile.
+  pub fn qos(&self) -> &QosProfile {
+    &self.qos
+  }
+}
+
+/// A ROS 2 node backed by a shared Zenoh session.
+pub struct Node {
+  context: Context,
+  node_name: NodeName,
+  node_id: u64,
+  zid: String,
+  next_entity_id: AtomicU64,
+}
+
+impl Node {
+  pub(crate) fn new(
+    context: Context,
+    node_name: NodeName,
+    node_id: u64,
+    _options: NodeOptions,
+  ) -> Self {
+    let zid = context.session().zid().to_string();
+    Self {
+      context,
+      node_name,
+      node_id,
+      zid,
+      next_entity_id: AtomicU64::new(0),
+    }
+  }
+
+  /// The node's name.
+  pub fn name(&self) -> &NodeName {
+    &self.node_name
+  }
+
+  /// The node's fully-qualified name (e.g. `/robot1/talker`).
+  pub fn fully_qualified_name(&self) -> String {
+    self.node_name.fully_qualified_name()
+  }
+
+  /// Create a [`Topic`] handle. `name` is resolved against the node namespace
+  /// if relative.
+  pub fn create_topic(&self, name: &Name, type_name: MessageTypeName, qos: &QosProfile) -> Topic {
+    Topic {
+      fully_qualified_name: resolve_fqn(name, &self.node_name),
+      dds_type_name: type_name.dds_msg_type(),
+      qos: qos.clone(),
+    }
+  }
+
+  /// Create a publisher for `topic`. `qos` overrides the topic QoS if given.
+  pub fn create_publisher<M: Serialize>(
+    &self,
+    topic: &Topic,
+    qos: Option<QosProfile>,
+  ) -> zenoh::Result<Publisher<M>> {
+    let _qos = qos.unwrap_or_else(|| topic.qos.clone());
+    let domain = self.context.domain_id();
+    let sender_hash = type_hash::sender_hash(&topic.dds_type_name);
+    // A publisher `put`s on a concrete key (real hash if known, else placeholder).
+    let key = keyexpr::topic_keyexpr(
+      domain,
+      &topic.fully_qualified_name,
+      &topic.dds_type_name,
+      sender_hash,
+    );
+    let zenoh_publisher = self.context.session().declare_publisher(key).wait()?;
+    let entity_id = self.next_entity_id.fetch_add(1, Ordering::Relaxed);
+    let source_gid = self.entity_gid(
+      entity_id,
+      keyexpr::EntityKind::Publisher,
+      topic,
+      sender_hash,
+    );
+    Ok(Publisher::new(zenoh_publisher, source_gid))
+  }
+
+  /// Create a subscription for `topic`. `qos` overrides the topic QoS if given.
+  pub fn create_subscription<M: DeserializeOwned>(
+    &self,
+    topic: &Topic,
+    qos: Option<QosProfile>,
+  ) -> zenoh::Result<Subscription<M>> {
+    let _qos = qos.unwrap_or_else(|| topic.qos.clone());
+    let domain = self.context.domain_id();
+    // A subscription listens with a wildcard type-hash to receive from any
+    // publisher regardless of its hash (liberal receive, ADR-0007).
+    let key = keyexpr::topic_keyexpr(
+      domain,
+      &topic.fully_qualified_name,
+      &topic.dds_type_name,
+      type_hash::WILDCARD,
+    );
+    let zenoh_subscriber = self.context.session().declare_subscriber(key).wait()?;
+    let _entity_id = self.next_entity_id.fetch_add(1, Ordering::Relaxed);
+    Ok(Subscription::new(zenoh_subscriber))
+  }
+
+  /// Compute the 16-byte GID of an entity from its liveliness key. The compact
+  /// QoS component is empty for now; E5 fills it in once QoS encoding lands.
+  fn entity_gid(
+    &self,
+    entity_id: u64,
+    kind: keyexpr::EntityKind,
+    topic: &Topic,
+    hash: &str,
+  ) -> [u8; 16] {
+    let ids = keyexpr::EntityIds {
+      session_id: &self.zid,
+      node_id: self.node_id,
+      entity_id,
+      enclave: "",
+      namespace: self.node_name.namespace(),
+      node_name: self.node_name.base_name(),
+    };
+    let liveliness_key = keyexpr::entity_liveliness_keyexpr(
+      self.context.domain_id(),
+      &ids,
+      kind,
+      &topic.fully_qualified_name,
+      &topic.dds_type_name,
+      hash,
+      "",
+    );
+    gid::gid_from_liveliness_key(&liveliness_key)
+  }
+}
+
+/// Resolve a topic [`Name`] to its fully-qualified form against a node name.
+/// Absolute names are used as-is; relative names are prefixed with the node
+/// namespace.
+fn resolve_fqn(name: &Name, node: &NodeName) -> String {
+  if name.is_absolute() {
+    format!("{name}")
+  } else {
+    let ns = node.namespace();
+    if ns == "/" {
+      format!("/{name}")
+    } else {
+      format!("{ns}/{name}")
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn fqn_resolution() {
+    let node = NodeName::new("/robot1", "talker").unwrap();
+    let rel = Name::new("", "chatter").unwrap();
+    assert_eq!(resolve_fqn(&rel, &node), "/robot1/chatter");
+
+    let root_node = NodeName::new("/", "talker").unwrap();
+    assert_eq!(resolve_fqn(&rel, &root_node), "/chatter");
+
+    let abs = Name::new("/", "chatter").unwrap();
+    assert_eq!(resolve_fqn(&abs, &node), "/chatter");
+  }
+}

--- a/src/zenoh_backend/parameters.rs
+++ b/src/zenoh_backend/parameters.rs
@@ -1,0 +1,555 @@
+//! Zenoh parameters (E8).
+//!
+//! ROS 2 parameters are not a middleware primitive — a node that "has
+//! parameters" simply exposes six ordinary services and a `parameter_events`
+//! topic (see `docs/zenoh_study/research/ros2_client_internals.md` and
+//! `rcl_interfaces`). This module builds that composition on top of the Zenoh
+//! service ([`super::service`]) and pub/sub ([`super::pubsub`]) layers, so the
+//! `ros2 param list/get/set` tooling — and rclcpp/rclpy parameter clients —
+//! interoperate with a `ros2-client` node.
+//!
+//! * `get_parameters` / `get_parameter_types` / `set_parameters` /
+//!   `set_parameters_atomically` / `list_parameters` / `describe_parameters`
+//!   services (`rcl_interfaces/srv/*`)
+//! * `parameter_events` topic (`rcl_interfaces/msg/ParameterEvent`)
+//!
+//! The event message carries an owned [`builtin_interfaces::Time`] timestamp,
+//! keeping the Zenoh backend independent of RustDDS (ADR-0004); the DDS
+//! backend's `parameters::raw::ParameterEvent` uses `rustdds::Timestamp`
+//! instead.
+//!
+//! Like the DDS backend's parameter machinery (which runs inside a `Spinner`),
+//! the server here is driven by the application: call [`ParameterServer::spin`]
+//! (or [`ParameterServer::spin_once`]) from your event loop to answer pending
+//! requests. `set_parameters_atomically` is not implemented (it returns a
+//! failure result, mirroring the DDS backend).
+
+use std::{collections::BTreeMap, sync::Mutex};
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+  pubsub::Publisher,
+  service::{Client, Server, ServiceError},
+};
+use crate::{
+  builtin_interfaces::Time,
+  parameters::{raw, Parameter, ParameterDescriptor, ParameterValue, SetParametersResult},
+  rcl_interfaces::{
+    DescribeParametersRequest, DescribeParametersResponse, GetParameterTypesRequest,
+    GetParameterTypesResponse, GetParametersRequest, GetParametersResponse, ListParametersRequest,
+    ListParametersResponse, ListParametersResult, SetParametersRequest, SetParametersResponse,
+  },
+};
+
+/// `rcl_interfaces/msg/ParameterEvent` with an owned
+/// [`builtin_interfaces::Time`] timestamp.
+///
+/// The field layout (and thus the CDR wire format) matches ROS 2's
+/// `ParameterEvent.msg`: `builtin_interfaces/Time stamp`, `string node`, and
+/// three `Parameter[]` arrays.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParameterEvent {
+  /// When the change happened.
+  pub stamp: Time,
+  /// Fully-qualified name of the node whose parameters changed.
+  pub node: String,
+  /// Parameters that were newly declared.
+  pub new_parameters: Vec<raw::Parameter>,
+  /// Parameters whose value changed.
+  pub changed_parameters: Vec<raw::Parameter>,
+  /// Parameters that were removed.
+  pub deleted_parameters: Vec<raw::Parameter>,
+}
+
+/// A ROS 2 parameter server over Zenoh: a parameter store plus the six
+/// `rcl_interfaces` services and the `parameter_events` publisher.
+///
+/// Create one with
+/// [`Node::create_parameter_server`](crate::Node::create_parameter_server),
+/// then call [`spin`](Self::spin) (or repeatedly
+/// [`spin_once`](Self::spin_once)) to service incoming requests.
+pub struct ParameterServer {
+  node_fqn: String,
+  store: Mutex<BTreeMap<String, ParameterValue>>,
+  get_parameters: Server<GetParametersRequest, GetParametersResponse>,
+  get_parameter_types: Server<GetParameterTypesRequest, GetParameterTypesResponse>,
+  set_parameters: Server<SetParametersRequest, SetParametersResponse>,
+  set_parameters_atomically: Server<SetParametersRequest, SetParametersResponse>,
+  list_parameters: Server<ListParametersRequest, ListParametersResponse>,
+  describe_parameters: Server<DescribeParametersRequest, DescribeParametersResponse>,
+  events: Publisher<ParameterEvent>,
+}
+
+impl ParameterServer {
+  #[allow(clippy::too_many_arguments)]
+  pub(crate) fn new(
+    node_fqn: String,
+    initial_parameters: impl IntoIterator<Item = Parameter>,
+    get_parameters: Server<GetParametersRequest, GetParametersResponse>,
+    get_parameter_types: Server<GetParameterTypesRequest, GetParameterTypesResponse>,
+    set_parameters: Server<SetParametersRequest, SetParametersResponse>,
+    set_parameters_atomically: Server<SetParametersRequest, SetParametersResponse>,
+    list_parameters: Server<ListParametersRequest, ListParametersResponse>,
+    describe_parameters: Server<DescribeParametersRequest, DescribeParametersResponse>,
+    events: Publisher<ParameterEvent>,
+  ) -> Self {
+    let mut store: BTreeMap<String, ParameterValue> = initial_parameters
+      .into_iter()
+      .map(|Parameter { name, value }| (name, value))
+      .collect();
+    // Every node carries `use_sim_time` (default false), like rclcpp/rclpy.
+    store
+      .entry("use_sim_time".to_string())
+      .or_insert(ParameterValue::Boolean(false));
+    Self {
+      node_fqn,
+      store: Mutex::new(store),
+      get_parameters,
+      get_parameter_types,
+      set_parameters,
+      set_parameters_atomically,
+      list_parameters,
+      describe_parameters,
+      events,
+    }
+  }
+
+  // --- local (in-process) parameter access ---------------------------------
+
+  /// Get a parameter's value, or `None` if it is not set.
+  pub fn get_parameter(&self, name: &str) -> Option<ParameterValue> {
+    self.store.lock().unwrap().get(name).cloned()
+  }
+
+  /// Set a parameter locally and publish a `parameter_events` notification.
+  pub fn set_parameter(&self, name: &str, value: ParameterValue) {
+    let _ = self.set_and_notify(name, value);
+  }
+
+  /// The names of all currently-set parameters.
+  pub fn parameter_names(&self) -> Vec<String> {
+    self.store.lock().unwrap().keys().cloned().collect()
+  }
+
+  fn set_and_notify(&self, name: &str, value: ParameterValue) -> SetParametersResult {
+    let raw_param = raw::Parameter {
+      name: name.to_string(),
+      value: value.clone().into(),
+    };
+    let already_set = {
+      let mut db = self.store.lock().unwrap();
+      let already = db.contains_key(name);
+      db.insert(name.to_string(), value);
+      already
+    };
+    if already_set {
+      self.publish_event(vec![], vec![raw_param], vec![]);
+    } else {
+      self.publish_event(vec![raw_param], vec![], vec![]);
+    }
+    Ok(())
+  }
+
+  fn publish_event(
+    &self,
+    new_parameters: Vec<raw::Parameter>,
+    changed_parameters: Vec<raw::Parameter>,
+    deleted_parameters: Vec<raw::Parameter>,
+  ) {
+    let event = ParameterEvent {
+      stamp: Time::now(),
+      node: self.node_fqn.clone(),
+      new_parameters,
+      changed_parameters,
+      deleted_parameters,
+    };
+    if let Err(e) = self.events.publish(event) {
+      log::warn!("parameter_events publish failed: {e}");
+    }
+  }
+
+  // --- request servicing ---------------------------------------------------
+
+  /// Answer every request currently pending on the six parameter services.
+  /// Non-blocking: returns once each service's queue is drained.
+  pub fn spin_once(&self) {
+    self.handle_get_parameters();
+    self.handle_get_parameter_types();
+    self.handle_set_parameters();
+    self.handle_set_parameters_atomically();
+    self.handle_list_parameters();
+    self.handle_describe_parameters();
+  }
+
+  /// Await and answer parameter requests until `stop()` returns `true`,
+  /// polling roughly every `poll` duration.
+  ///
+  /// This is a convenience loop for applications that dedicate a thread to the
+  /// parameter server; integrate [`spin_once`](Self::spin_once) into your own
+  /// event loop instead if you already have one.
+  pub fn spin(&self, poll: std::time::Duration, mut stop: impl FnMut() -> bool) {
+    while !stop() {
+      self.spin_once();
+      std::thread::sleep(poll);
+    }
+  }
+
+  fn handle_get_parameters(&self) {
+    while let Ok(Some((id, req))) = self.get_parameters.try_receive_request() {
+      let values = {
+        let db = self.store.lock().unwrap();
+        req
+          .names
+          .iter()
+          .map(|name| db.get(name).cloned().unwrap_or(ParameterValue::NotSet))
+          .map(raw::ParameterValue::from)
+          .collect()
+      };
+      if let Err(e) = self
+        .get_parameters
+        .send_response(id, GetParametersResponse { values })
+      {
+        log::warn!("get_parameters response failed: {e}");
+      }
+    }
+  }
+
+  fn handle_get_parameter_types(&self) {
+    while let Ok(Some((id, req))) = self.get_parameter_types.try_receive_request() {
+      let values = {
+        let db = self.store.lock().unwrap();
+        req
+          .names
+          .iter()
+          .map(|name| db.get(name).cloned().unwrap_or(ParameterValue::NotSet))
+          .map(|v| v.to_parameter_type() as u8)
+          .collect()
+      };
+      if let Err(e) = self
+        .get_parameter_types
+        .send_response(id, GetParameterTypesResponse { values })
+      {
+        log::warn!("get_parameter_types response failed: {e}");
+      }
+    }
+  }
+
+  fn handle_set_parameters(&self) {
+    while let Ok(Some((id, req))) = self.set_parameters.try_receive_request() {
+      let results = req
+        .parameter
+        .iter()
+        .cloned()
+        .map(Parameter::from)
+        .map(|Parameter { name, value }| self.set_and_notify(&name, value))
+        .map(raw::SetParametersResult::from)
+        .collect();
+      if let Err(e) = self
+        .set_parameters
+        .send_response(id, SetParametersResponse { results })
+      {
+        log::warn!("set_parameters response failed: {e}");
+      }
+    }
+  }
+
+  fn handle_set_parameters_atomically(&self) {
+    while let Ok(Some((id, req))) = self.set_parameters_atomically.try_receive_request() {
+      // Not implemented — mirror the DDS backend and fail every entry.
+      let results = req
+        .parameter
+        .iter()
+        .map(|_| {
+          raw::SetParametersResult::from(Err(
+            "Setting parameters atomically is not implemented.".to_owned(),
+          ))
+        })
+        .collect();
+      if let Err(e) = self
+        .set_parameters_atomically
+        .send_response(id, SetParametersResponse { results })
+      {
+        log::warn!("set_parameters_atomically response failed: {e}");
+      }
+    }
+  }
+
+  fn handle_list_parameters(&self) {
+    while let Ok(Some((id, req))) = self.list_parameters.try_receive_request() {
+      let names = {
+        let db = self.store.lock().unwrap();
+        db.keys()
+          .filter(|name| {
+            req.prefixes.is_empty() || req.prefixes.iter().any(|p| name.starts_with(p))
+          })
+          .cloned()
+          .collect()
+      };
+      let result = ListParametersResult {
+        names,
+        prefixes: vec![],
+      };
+      if let Err(e) = self
+        .list_parameters
+        .send_response(id, ListParametersResponse { result })
+      {
+        log::warn!("list_parameters response failed: {e}");
+      }
+    }
+  }
+
+  fn handle_describe_parameters(&self) {
+    while let Ok(Some((id, req))) = self.describe_parameters.try_receive_request() {
+      let values = {
+        let db = self.store.lock().unwrap();
+        req
+          .names
+          .iter()
+          .map(|name| match db.get(name) {
+            Some(value) => ParameterDescriptor::from_value(name, value),
+            None => ParameterDescriptor::unknown(name),
+          })
+          .map(raw::ParameterDescriptor::from)
+          .collect()
+      };
+      if let Err(e) = self
+        .describe_parameters
+        .send_response(id, DescribeParametersResponse { values })
+      {
+        log::warn!("describe_parameters response failed: {e}");
+      }
+    }
+  }
+}
+
+/// A client for a remote node's parameter services.
+///
+/// Create one with
+/// [`Node::create_parameter_client`](crate::Node::create_parameter_client),
+/// pointing at the node that hosts the parameters.
+pub struct ParameterClient {
+  get_parameters: Client<GetParametersRequest, GetParametersResponse>,
+  get_parameter_types: Client<GetParameterTypesRequest, GetParameterTypesResponse>,
+  set_parameters: Client<SetParametersRequest, SetParametersResponse>,
+  list_parameters: Client<ListParametersRequest, ListParametersResponse>,
+  describe_parameters: Client<DescribeParametersRequest, DescribeParametersResponse>,
+}
+
+impl ParameterClient {
+  #[allow(clippy::too_many_arguments)]
+  pub(crate) fn new(
+    get_parameters: Client<GetParametersRequest, GetParametersResponse>,
+    get_parameter_types: Client<GetParameterTypesRequest, GetParameterTypesResponse>,
+    set_parameters: Client<SetParametersRequest, SetParametersResponse>,
+    list_parameters: Client<ListParametersRequest, ListParametersResponse>,
+    describe_parameters: Client<DescribeParametersRequest, DescribeParametersResponse>,
+  ) -> Self {
+    Self {
+      get_parameters,
+      get_parameter_types,
+      set_parameters,
+      list_parameters,
+      describe_parameters,
+    }
+  }
+
+  /// Get the values of the named parameters (blocking). Unset parameters come
+  /// back as [`ParameterValue::NotSet`].
+  pub fn get_parameters(&self, names: &[&str]) -> Result<Vec<ParameterValue>, ServiceError> {
+    let req = GetParametersRequest {
+      names: names.iter().map(|s| s.to_string()).collect(),
+    };
+    let resp = self.get_parameters.call(req)?;
+    Ok(resp.values.into_iter().map(ParameterValue::from).collect())
+  }
+
+  /// Get the [`ParameterType`](crate::parameters::ParameterType) codes of the
+  /// named parameters (blocking).
+  pub fn get_parameter_types(&self, names: &[&str]) -> Result<Vec<u8>, ServiceError> {
+    let req = GetParameterTypesRequest {
+      names: names.iter().map(|s| s.to_string()).collect(),
+    };
+    Ok(self.get_parameter_types.call(req)?.values)
+  }
+
+  /// Set parameters (blocking). Returns a per-parameter success/reason result.
+  pub fn set_parameters(
+    &self,
+    parameters: impl IntoIterator<Item = Parameter>,
+  ) -> Result<Vec<SetParametersResult>, ServiceError> {
+    let req = SetParametersRequest {
+      parameter: parameters.into_iter().map(raw::Parameter::from).collect(),
+    };
+    let resp = self.set_parameters.call(req)?;
+    Ok(
+      resp
+        .results
+        .into_iter()
+        .map(|r| if r.successful { Ok(()) } else { Err(r.reason) })
+        .collect(),
+    )
+  }
+
+  /// List parameter names, optionally filtered by prefix (blocking).
+  pub fn list_parameters(&self, prefixes: &[&str]) -> Result<Vec<String>, ServiceError> {
+    let req = ListParametersRequest {
+      prefixes: prefixes.iter().map(|s| s.to_string()).collect(),
+      depth: 0,
+    };
+    Ok(self.list_parameters.call(req)?.result.names)
+  }
+
+  /// Describe the named parameters (blocking).
+  pub fn describe_parameters(
+    &self,
+    names: &[&str],
+  ) -> Result<Vec<raw::ParameterDescriptor>, ServiceError> {
+    let req = DescribeParametersRequest {
+      names: names.iter().map(|s| s.to_string()).collect(),
+    };
+    Ok(self.describe_parameters.call(req)?.values)
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use std::{
+    sync::{
+      atomic::{AtomicBool, Ordering},
+      Arc,
+    },
+    time::{Duration, Instant},
+  };
+
+  use zenoh::Config;
+
+  use crate::{
+    parameters::ParameterType, Context, ContextOptions, Name, NodeName, NodeOptions, Parameter,
+    ParameterValue,
+  };
+
+  fn make_config(listen_port: u16, connect_port: Option<u16>) -> Config {
+    let mut c = Config::default();
+    c.insert_json5("mode", "\"peer\"").unwrap();
+    c.insert_json5("scouting/multicast/enabled", "false")
+      .unwrap();
+    c.insert_json5(
+      "listen/endpoints",
+      &format!("[\"tcp/127.0.0.1:{listen_port}\"]"),
+    )
+    .unwrap();
+    if let Some(p) = connect_port {
+      c.insert_json5("connect/endpoints", &format!("[\"tcp/127.0.0.1:{p}\"]"))
+        .unwrap();
+    }
+    c
+  }
+
+  #[test]
+  fn parameter_get_set_list_roundtrip() {
+    let srv_port = 17523;
+    let cli_port = 17524;
+    let srv_ctx =
+      Context::with_options(ContextOptions::new().zenoh_config(make_config(srv_port, None)))
+        .unwrap();
+    let cli_ctx = Context::with_options(
+      ContextOptions::new().zenoh_config(make_config(cli_port, Some(srv_port))),
+    )
+    .unwrap();
+
+    let srv_node_name = NodeName::new("/", "param_holder").unwrap();
+    let srv_node = srv_ctx.new_node(srv_node_name.clone(), NodeOptions::new());
+    let cli_node = cli_ctx.new_node(
+      NodeName::new("/", "param_client").unwrap(),
+      NodeOptions::new(),
+    );
+
+    let server = srv_node
+      .create_parameter_server([Parameter {
+        name: "speed".to_string(),
+        value: ParameterValue::Double(1.0),
+      }])
+      .unwrap();
+    let client = cli_node.create_parameter_client(&srv_node_name).unwrap();
+
+    // Server: answer requests in a background thread.
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_srv = stop.clone();
+    let server_thread = std::thread::spawn(move || {
+      let deadline = Instant::now() + Duration::from_secs(30);
+      while !stop_srv.load(Ordering::Relaxed) && Instant::now() < deadline {
+        server.spin_once();
+        std::thread::sleep(Duration::from_millis(20));
+      }
+      // Report the final state back to the test.
+      server.get_parameter("speed")
+    });
+
+    // Client: retry until the peers connect and the queryables are discovered.
+    let deadline = Instant::now() + Duration::from_secs(30);
+
+    // get the initial value
+    let mut initial = None;
+    while Instant::now() < deadline {
+      if let Ok(vals) = client.get_parameters(&["speed"]) {
+        initial = Some(vals);
+        break;
+      }
+      std::thread::sleep(Duration::from_millis(200));
+    }
+    assert_eq!(initial.as_deref(), Some(&[ParameterValue::Double(1.0)][..]));
+
+    // set a new value + a brand-new parameter
+    let set_results = client
+      .set_parameters([
+        Parameter {
+          name: "speed".to_string(),
+          value: ParameterValue::Double(2.5),
+        },
+        Parameter {
+          name: "name".to_string(),
+          value: ParameterValue::String("robby".to_string()),
+        },
+      ])
+      .expect("set_parameters call");
+    assert_eq!(set_results.len(), 2);
+    assert!(set_results.iter().all(|r| r.is_ok()));
+
+    // read back the changed value
+    let got = client.get_parameters(&["speed"]).expect("get after set");
+    assert_eq!(got, vec![ParameterValue::Double(2.5)]);
+
+    // types
+    let types = client
+      .get_parameter_types(&["speed", "name"])
+      .expect("get_parameter_types");
+    assert_eq!(
+      types,
+      vec![ParameterType::Double as u8, ParameterType::String as u8]
+    );
+
+    // list should include the built-in use_sim_time plus our params
+    let names = client.list_parameters(&[]).expect("list_parameters");
+    assert!(names.contains(&"speed".to_string()));
+    assert!(names.contains(&"name".to_string()));
+    assert!(names.contains(&"use_sim_time".to_string()));
+
+    // prefix filter
+    let filtered = client.list_parameters(&["spe"]).expect("list w/ prefix");
+    assert_eq!(filtered, vec!["speed".to_string()]);
+
+    // an unset parameter comes back as NotSet
+    let missing = client.get_parameters(&["nope"]).expect("get missing");
+    assert_eq!(missing, vec![ParameterValue::NotSet]);
+
+    stop.store(true, Ordering::Relaxed);
+    let final_speed = server_thread.join().unwrap();
+    assert_eq!(final_speed, Some(ParameterValue::Double(2.5)));
+
+    // sanity: the client can reach the server's namespaced services
+    let _ = Name::new("/param_holder", "get_parameters").unwrap();
+  }
+}

--- a/src/zenoh_backend/pubsub.rs
+++ b/src/zenoh_backend/pubsub.rs
@@ -15,6 +15,7 @@ use std::{
 use serde::{de::DeserializeOwned, Serialize};
 use zenoh::{
   handlers::FifoChannelHandler,
+  liveliness::LivelinessToken,
   pubsub::{Publisher as ZenohPublisher, Subscriber},
   sample::Sample,
   Wait,
@@ -101,15 +102,22 @@ pub struct Publisher<M> {
   zenoh_publisher: ZenohPublisher<'static>,
   seq: AtomicI64,
   source_gid: [u8; 16],
+  // Kept alive so the entity stays discoverable; dropped => token undeclared.
+  _liveliness_token: Option<LivelinessToken>,
   phantom: PhantomData<fn() -> M>,
 }
 
 impl<M: Serialize> Publisher<M> {
-  pub(crate) fn new(zenoh_publisher: ZenohPublisher<'static>, source_gid: [u8; 16]) -> Self {
+  pub(crate) fn new(
+    zenoh_publisher: ZenohPublisher<'static>,
+    source_gid: [u8; 16],
+    liveliness_token: Option<LivelinessToken>,
+  ) -> Self {
     Self {
       zenoh_publisher,
       seq: AtomicI64::new(0),
       source_gid,
+      _liveliness_token: liveliness_token,
       phantom: PhantomData,
     }
   }
@@ -157,13 +165,19 @@ impl<M: Serialize> Publisher<M> {
 /// A ROS 2 subscription over Zenoh.
 pub struct Subscription<M> {
   zenoh_subscriber: Subscriber<FifoChannelHandler<Sample>>,
+  // Kept alive so the entity stays discoverable; dropped => token undeclared.
+  _liveliness_token: Option<LivelinessToken>,
   phantom: PhantomData<fn() -> M>,
 }
 
 impl<M: DeserializeOwned> Subscription<M> {
-  pub(crate) fn new(zenoh_subscriber: Subscriber<FifoChannelHandler<Sample>>) -> Self {
+  pub(crate) fn new(
+    zenoh_subscriber: Subscriber<FifoChannelHandler<Sample>>,
+    liveliness_token: Option<LivelinessToken>,
+  ) -> Self {
     Self {
       zenoh_subscriber,
+      _liveliness_token: liveliness_token,
       phantom: PhantomData,
     }
   }

--- a/src/zenoh_backend/pubsub.rs
+++ b/src/zenoh_backend/pubsub.rs
@@ -1,0 +1,289 @@
+//! Zenoh `Publisher` and `Subscription` (E4).
+//!
+//! A publisher `put`s a CDR payload (see [`super::cdr`]) with an
+//! [`AttachmentData`] carrying `(sequence, source_timestamp, source_gid)` — the
+//! `rmw_zenoh` message shape. A subscription declares a Zenoh subscriber with a
+//! wildcard type-hash (liberal receive, ADR-0007) and yields decoded messages
+//! plus their [`MessageInfo`].
+
+use std::{
+  marker::PhantomData,
+  sync::atomic::{AtomicI64, Ordering},
+  time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::{de::DeserializeOwned, Serialize};
+use zenoh::{
+  handlers::FifoChannelHandler,
+  pubsub::{Publisher as ZenohPublisher, Subscriber},
+  sample::Sample,
+  Wait,
+};
+
+use super::{attachment::AttachmentData, cdr};
+
+/// Metadata about a received message, extracted from its Zenoh attachment.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MessageInfo {
+  source_timestamp_nanos: i64,
+  sequence_number: i64,
+  source_gid: [u8; 16],
+}
+
+impl MessageInfo {
+  /// Source timestamp (ns since UNIX epoch) set by the publisher, or 0 if the
+  /// message carried no ROS attachment.
+  pub fn source_timestamp_nanos(&self) -> i64 {
+    self.source_timestamp_nanos
+  }
+
+  /// Per-publisher sequence number of this message.
+  pub fn sequence_number(&self) -> i64 {
+    self.sequence_number
+  }
+
+  /// 16-byte GID of the publishing entity.
+  pub fn source_gid(&self) -> [u8; 16] {
+    self.source_gid
+  }
+}
+
+/// Failure to publish a message.
+#[derive(Debug)]
+pub enum PublishError {
+  /// CDR serialization of the message failed.
+  Cdr(cdr::CdrError),
+  /// The Zenoh `put` failed.
+  Zenoh(zenoh::Error),
+}
+
+impl std::fmt::Display for PublishError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      PublishError::Cdr(e) => write!(f, "publish: {e}"),
+      PublishError::Zenoh(e) => write!(f, "publish: zenoh error: {e}"),
+    }
+  }
+}
+impl std::error::Error for PublishError {}
+
+/// Failure to receive/decode a message.
+#[derive(Debug)]
+pub enum TakeError {
+  /// CDR deserialization failed.
+  Cdr(cdr::CdrError),
+  /// The message attachment was malformed.
+  Attachment,
+  /// The subscriber channel was closed.
+  Closed,
+}
+
+impl std::fmt::Display for TakeError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      TakeError::Cdr(e) => write!(f, "take: {e}"),
+      TakeError::Attachment => write!(f, "take: malformed attachment"),
+      TakeError::Closed => write!(f, "take: subscriber closed"),
+    }
+  }
+}
+impl std::error::Error for TakeError {}
+
+fn now_nanos() -> i64 {
+  SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .map(|d| d.as_nanos() as i64)
+    .unwrap_or(0)
+}
+
+/// A ROS 2 publisher over Zenoh.
+pub struct Publisher<M> {
+  zenoh_publisher: ZenohPublisher<'static>,
+  seq: AtomicI64,
+  source_gid: [u8; 16],
+  phantom: PhantomData<fn() -> M>,
+}
+
+impl<M: Serialize> Publisher<M> {
+  pub(crate) fn new(zenoh_publisher: ZenohPublisher<'static>, source_gid: [u8; 16]) -> Self {
+    Self {
+      zenoh_publisher,
+      seq: AtomicI64::new(0),
+      source_gid,
+      phantom: PhantomData,
+    }
+  }
+
+  fn encode(&self, msg: &M) -> Result<(Vec<u8>, zenoh::bytes::ZBytes), PublishError> {
+    let payload = cdr::to_cdr(msg).map_err(PublishError::Cdr)?;
+    let sequence_number = self.seq.fetch_add(1, Ordering::Relaxed) + 1; // start at 1
+    let attachment = AttachmentData {
+      sequence_number,
+      source_timestamp: now_nanos(),
+      source_gid: self.source_gid,
+    }
+    .to_zbytes();
+    Ok((payload, attachment))
+  }
+
+  /// Publish a message (async).
+  pub async fn async_publish(&self, msg: M) -> Result<(), PublishError> {
+    let (payload, attachment) = self.encode(&msg)?;
+    self
+      .zenoh_publisher
+      .put(payload)
+      .attachment(attachment)
+      .await
+      .map_err(PublishError::Zenoh)
+  }
+
+  /// Publish a message (blocking).
+  pub fn publish(&self, msg: M) -> Result<(), PublishError> {
+    let (payload, attachment) = self.encode(&msg)?;
+    self
+      .zenoh_publisher
+      .put(payload)
+      .attachment(attachment)
+      .wait()
+      .map_err(PublishError::Zenoh)
+  }
+
+  /// This publisher's 16-byte source GID.
+  pub fn gid(&self) -> [u8; 16] {
+    self.source_gid
+  }
+}
+
+/// A ROS 2 subscription over Zenoh.
+pub struct Subscription<M> {
+  zenoh_subscriber: Subscriber<FifoChannelHandler<Sample>>,
+  phantom: PhantomData<fn() -> M>,
+}
+
+impl<M: DeserializeOwned> Subscription<M> {
+  pub(crate) fn new(zenoh_subscriber: Subscriber<FifoChannelHandler<Sample>>) -> Self {
+    Self {
+      zenoh_subscriber,
+      phantom: PhantomData,
+    }
+  }
+
+  fn decode(sample: &Sample) -> Result<(M, MessageInfo), TakeError> {
+    let payload = sample.payload().to_bytes();
+    let msg = cdr::from_cdr::<M>(&payload).map_err(TakeError::Cdr)?;
+    let info = match sample.attachment() {
+      Some(zbytes) => {
+        let a = AttachmentData::from_zbytes(zbytes).map_err(|_| TakeError::Attachment)?;
+        MessageInfo {
+          source_timestamp_nanos: a.source_timestamp,
+          sequence_number: a.sequence_number,
+          source_gid: a.source_gid,
+        }
+      }
+      None => MessageInfo::default(),
+    };
+    Ok((msg, info))
+  }
+
+  /// Await the next message and its metadata.
+  pub async fn async_take(&self) -> Result<(M, MessageInfo), TakeError> {
+    let sample = self
+      .zenoh_subscriber
+      .recv_async()
+      .await
+      .map_err(|_| TakeError::Closed)?;
+    Self::decode(&sample)
+  }
+
+  /// Take a message if one is immediately available (non-blocking).
+  pub fn try_take(&self) -> Result<Option<(M, MessageInfo)>, TakeError> {
+    match self.zenoh_subscriber.try_recv() {
+      Ok(Some(sample)) => Self::decode(&sample).map(Some),
+      Ok(None) => Ok(None),
+      Err(_) => Err(TakeError::Closed),
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use std::time::{Duration, Instant};
+
+  use zenoh::Config;
+
+  use super::{Publisher, Subscription};
+  use crate::{Context, ContextOptions, MessageTypeName, Name, NodeName, NodeOptions, QosProfile};
+
+  // Build a peer config on IPv4 loopback with multicast off. `listen`/`connect`
+  // pin explicit ports so two in-process peers connect directly — no router
+  // (matches Tier B in docs/zenoh_study/test_plan.md).
+  fn make_config(listen_port: u16, connect_port: Option<u16>) -> Config {
+    let mut c = Config::default();
+    c.insert_json5("mode", "\"peer\"").unwrap();
+    c.insert_json5("scouting/multicast/enabled", "false")
+      .unwrap();
+    c.insert_json5(
+      "listen/endpoints",
+      &format!("[\"tcp/127.0.0.1:{listen_port}\"]"),
+    )
+    .unwrap();
+    if let Some(p) = connect_port {
+      c.insert_json5("connect/endpoints", &format!("[\"tcp/127.0.0.1:{p}\"]"))
+        .unwrap();
+    }
+    c
+  }
+
+  #[test]
+  fn pub_sub_roundtrip_in_process() {
+    // Distinct fixed ports (CI runs zenoh tests with --test-threads=1).
+    let sub_port = 17513;
+    let pub_port = 17514;
+
+    let sub_ctx =
+      Context::with_options(ContextOptions::new().zenoh_config(make_config(sub_port, None)))
+        .expect("open subscriber context");
+    let pub_ctx = Context::with_options(
+      ContextOptions::new().zenoh_config(make_config(pub_port, Some(sub_port))),
+    )
+    .expect("open publisher context");
+
+    let sub_node = sub_ctx.new_node(NodeName::new("/", "test_sub").unwrap(), NodeOptions::new());
+    let pub_node = pub_ctx.new_node(NodeName::new("/", "test_pub").unwrap(), NodeOptions::new());
+
+    let make_topic = |n: &crate::Node| {
+      n.create_topic(
+        &Name::new("/", "chatter").unwrap(),
+        MessageTypeName::new("std_msgs", "String"),
+        &QosProfile::default(),
+      )
+    };
+    let sub: Subscription<String> = sub_node
+      .create_subscription(&make_topic(&sub_node), None)
+      .expect("create subscription");
+    let publisher: Publisher<String> = pub_node
+      .create_publisher(&make_topic(&pub_node), None)
+      .expect("create publisher");
+
+    // Publish repeatedly until the peers have connected and a sample arrives.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut got = None;
+    while Instant::now() < deadline {
+      publisher
+        .publish("hello zenoh!".to_string())
+        .expect("publish");
+      if let Some(m) = sub.try_take().expect("try_take") {
+        got = Some(m);
+        break;
+      }
+      std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let (msg, info) = got.expect("no message received within timeout");
+    assert_eq!(msg, "hello zenoh!");
+    assert!(info.sequence_number() >= 1);
+    assert_ne!(info.source_gid(), [0u8; 16]);
+  }
+}

--- a/src/zenoh_backend/qos_encoding.rs
+++ b/src/zenoh_backend/qos_encoding.rs
@@ -1,0 +1,231 @@
+//! Compact QoS encoding for Zenoh liveliness tokens (E5).
+//!
+//! `rmw_zenoh` embeds a QoS string in each liveliness token's `<qos>` component
+//! (see `docs/zenoh_study/research/rmw_zenoh.md` §6). The layout is six
+//! `:`-separated groups:
+//!
+//! ```text
+//! <rel>:<dur>:<hist>,<depth>:<dl_s>,<dl_ns>:<ls_s>,<ls_ns>:<liv>,<lease_s>,<lease_ns>
+//! ```
+//!
+//! Every field except **depth** is *delta-encoded*: it is emitted only when it
+//! differs from the RMW default profile, otherwise left empty and filled from
+//! the default on decode. **Depth is always emitted.** This reproduces the
+//! documented examples, e.g. a reliable/volatile/keep-last publisher with depth
+//! 7 encodes as `::,7:,:,:,,`.
+//!
+//! Numeric policy codes match `rmw_qos_policy_*_t`. Byte-exact parity with C++
+//! peers is confirmed by live interop (ADR-0007/0009); this module is unit
+//! tested for the documented vectors and for round-tripping.
+
+use std::time::Duration;
+
+use crate::qos::{Durability, History, Liveliness, QosProfile, Reliability};
+
+// RMW default profile (`rmw_qos_profile_default`) used as the delta reference.
+const DEFAULT_RELIABILITY: Reliability = Reliability::Reliable;
+const DEFAULT_DURABILITY: Durability = Durability::Volatile;
+const DEFAULT_LIVELINESS: Liveliness = Liveliness::Automatic;
+// Default history is KEEP_LAST; only KEEP_ALL is non-default.
+
+fn reliability_code(r: Reliability) -> &'static str {
+  match r {
+    Reliability::Reliable => "1",
+    Reliability::BestEffort => "2",
+  }
+}
+
+fn durability_code(d: Durability) -> &'static str {
+  match d {
+    Durability::TransientLocal => "1",
+    Durability::Volatile => "2",
+  }
+}
+
+fn liveliness_code(l: Liveliness) -> &'static str {
+  match l {
+    Liveliness::Automatic => "1",
+    Liveliness::ManualByTopic => "3",
+  }
+}
+
+// A duration renders as two fields "<sec>,<nsec>"; `None` (infinite/default)
+// renders as two empty fields.
+fn duration_fields(d: Option<Duration>) -> (String, String) {
+  match d {
+    None => (String::new(), String::new()),
+    Some(d) => (d.as_secs().to_string(), d.subsec_nanos().to_string()),
+  }
+}
+
+/// Encode a [`QosProfile`] into the compact liveliness `<qos>` string.
+pub fn encode_qos(q: &QosProfile) -> String {
+  let rel = if q.reliability == DEFAULT_RELIABILITY {
+    ""
+  } else {
+    reliability_code(q.reliability)
+  };
+  let dur = if q.durability == DEFAULT_DURABILITY {
+    ""
+  } else {
+    durability_code(q.durability)
+  };
+  let (hist, depth) = match q.history {
+    History::KeepLast { depth } => ("", depth),
+    History::KeepAll => ("2", 0),
+  };
+  let liv = if q.liveliness == DEFAULT_LIVELINESS {
+    ""
+  } else {
+    liveliness_code(q.liveliness)
+  };
+  let (dl_s, dl_ns) = duration_fields(q.deadline);
+  let (ls_s, ls_ns) = duration_fields(q.lifespan);
+  let (lease_s, lease_ns) = duration_fields(q.liveliness_lease);
+
+  format!("{rel}:{dur}:{hist},{depth}:{dl_s},{dl_ns}:{ls_s},{ls_ns}:{liv},{lease_s},{lease_ns}")
+}
+
+/// Failure to parse a compact QoS string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QosDecodeError;
+
+fn parse_duration(sec: &str, nsec: &str) -> Result<Option<Duration>, QosDecodeError> {
+  match (sec.is_empty(), nsec.is_empty()) {
+    (true, true) => Ok(None),
+    _ => {
+      let s: u64 = sec.parse().map_err(|_| QosDecodeError)?;
+      let ns: u32 = nsec.parse().map_err(|_| QosDecodeError)?;
+      Ok(Some(Duration::new(s, ns)))
+    }
+  }
+}
+
+/// Decode a compact liveliness `<qos>` string into a [`QosProfile`], filling
+/// empty (default) fields from the RMW default profile.
+pub fn decode_qos(s: &str) -> Result<QosProfile, QosDecodeError> {
+  let groups: Vec<&str> = s.split(':').collect();
+  if groups.len() != 6 {
+    return Err(QosDecodeError);
+  }
+
+  let reliability = match groups[0] {
+    "" => DEFAULT_RELIABILITY,
+    "1" => Reliability::Reliable,
+    "2" => Reliability::BestEffort,
+    _ => return Err(QosDecodeError),
+  };
+  let durability = match groups[1] {
+    "" => DEFAULT_DURABILITY,
+    "1" => Durability::TransientLocal,
+    "2" => Durability::Volatile,
+    _ => return Err(QosDecodeError),
+  };
+
+  // history group: "<hist>,<depth>"
+  let (hist_str, depth_str) = groups[2].split_once(',').ok_or(QosDecodeError)?;
+  let depth: usize = if depth_str.is_empty() {
+    0
+  } else {
+    depth_str.parse().map_err(|_| QosDecodeError)?
+  };
+  let history = match hist_str {
+    "" | "1" => History::KeepLast { depth },
+    "2" => History::KeepAll,
+    _ => return Err(QosDecodeError),
+  };
+
+  let (dl_s, dl_ns) = groups[3].split_once(',').ok_or(QosDecodeError)?;
+  let deadline = parse_duration(dl_s, dl_ns)?;
+  let (ls_s, ls_ns) = groups[4].split_once(',').ok_or(QosDecodeError)?;
+  let lifespan = parse_duration(ls_s, ls_ns)?;
+
+  // liveliness group: "<liv>,<lease_s>,<lease_ns>"
+  let mut liv_parts = groups[5].splitn(3, ',');
+  let liv_str = liv_parts.next().unwrap_or("");
+  let lease_s = liv_parts.next().unwrap_or("");
+  let lease_ns = liv_parts.next().unwrap_or("");
+  let liveliness = match liv_str {
+    "" => DEFAULT_LIVELINESS,
+    "1" => Liveliness::Automatic,
+    "3" => Liveliness::ManualByTopic,
+    _ => return Err(QosDecodeError),
+  };
+  let liveliness_lease = parse_duration(lease_s, lease_ns)?;
+
+  Ok(QosProfile {
+    reliability,
+    durability,
+    history,
+    deadline,
+    lifespan,
+    liveliness,
+    liveliness_lease,
+  })
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // The rmw_zenoh talker/listener examples: reliable, volatile, keep-last,
+  // automatic, no deadline/lifespan/lease — only depth differs.
+  fn keep_last(depth: usize) -> QosProfile {
+    QosProfile {
+      reliability: Reliability::Reliable,
+      durability: Durability::Volatile,
+      history: History::KeepLast { depth },
+      deadline: None,
+      lifespan: None,
+      liveliness: Liveliness::Automatic,
+      liveliness_lease: None,
+    }
+  }
+
+  #[test]
+  fn matches_rmw_zenoh_examples() {
+    assert_eq!(encode_qos(&keep_last(7)), "::,7:,:,:,,");
+    assert_eq!(encode_qos(&keep_last(10)), "::,10:,:,:,,");
+  }
+
+  #[test]
+  fn round_trips() {
+    let profiles = [
+      keep_last(7),
+      keep_last(10),
+      QosProfile {
+        reliability: Reliability::BestEffort,
+        durability: Durability::TransientLocal,
+        history: History::KeepAll,
+        deadline: Some(Duration::new(1, 500)),
+        lifespan: Some(Duration::new(10, 0)),
+        liveliness: Liveliness::ManualByTopic,
+        liveliness_lease: Some(Duration::new(2, 0)),
+      },
+    ];
+    for p in profiles {
+      let encoded = encode_qos(&p);
+      let decoded = decode_qos(&encoded).expect("decode");
+      // KeepAll loses depth (rmw uses 0); compare via re-encode for stability.
+      assert_eq!(
+        encode_qos(&decoded),
+        encoded,
+        "re-encode mismatch for {p:?}"
+      );
+    }
+  }
+
+  #[test]
+  fn decode_examples() {
+    assert_eq!(decode_qos("::,7:,:,:,,").unwrap(), keep_last(7));
+    assert_eq!(decode_qos("::,10:,:,:,,").unwrap(), keep_last(10));
+  }
+
+  #[test]
+  fn rejects_malformed() {
+    assert_eq!(decode_qos("too:few:groups"), Err(QosDecodeError));
+    assert_eq!(decode_qos(""), Err(QosDecodeError));
+  }
+}

--- a/src/zenoh_backend/rosout.rs
+++ b/src/zenoh_backend/rosout.rs
@@ -1,0 +1,199 @@
+//! Zenoh rosout logging (E9).
+//!
+//! ROS 2 nodes publish log records to the global `/rosout` topic
+//! (`rcl_interfaces/msg/Log`). This module provides a [`Logger`] that `put`s
+//! those records on the corresponding Zenoh key, plus an optional inbound
+//! [`Subscription`] for reading `/rosout` (the `read_rosout` capability).
+//!
+//! The record carries an owned [`builtin_interfaces::Time`] timestamp, keeping
+//! the Zenoh backend independent of RustDDS (ADR-0004); the DDS backend's
+//! [`crate::log::Log`] uses `rustdds::Timestamp` instead. The field layout (and
+//! thus the CDR wire format) matches `rcl_interfaces/msg/Log`, so
+//! `ros2 topic echo /rosout` shows records logged by a `ros2-client` node.
+
+use serde::{Deserialize, Serialize};
+
+use super::pubsub::Publisher;
+use crate::{builtin_interfaces::Time, log::LogLevel};
+
+/// A `rcl_interfaces/msg/Log` record with an owned
+/// [`builtin_interfaces::Time`] timestamp.
+///
+/// Field order matches ROS 2's `Log.msg`: `stamp`, `level`, `name`, `msg`,
+/// `file`, `function`, `line`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Log {
+  /// When the record was produced.
+  pub stamp: Time,
+  /// Severity level (see [`LogLevel`]).
+  pub level: u8,
+  /// Name of the logger (usually the node name).
+  pub name: String,
+  /// The log message.
+  pub msg: String,
+  /// Source file the record came from.
+  pub file: String,
+  /// Source function the record came from.
+  pub function: String,
+  /// Source line the record came from.
+  pub line: u32,
+}
+
+/// A rosout logger: publishes [`Log`] records to the global `/rosout` topic.
+///
+/// Create one with [`Node::create_logger`](crate::Node::create_logger). The
+/// `name` field of each record defaults to the node's base name. Use the
+/// [`rosout!`](crate::rosout!) macro to capture source location automatically,
+/// or call [`log_at`](Self::log_at) / the level helpers directly.
+pub struct Logger {
+  node_name: String,
+  publisher: Publisher<Log>,
+}
+
+impl Logger {
+  pub(crate) fn new(node_name: String, publisher: Publisher<Log>) -> Self {
+    Self {
+      node_name,
+      publisher,
+    }
+  }
+
+  /// The logger name (the node's base name) stamped into each record.
+  pub fn name(&self) -> &str {
+    &self.node_name
+  }
+
+  /// Publish a log record, specifying the source location explicitly.
+  ///
+  /// Prefer the [`rosout!`](crate::rosout!) macro, which fills `file`/`line`
+  /// from the call site.
+  pub fn log_at(&self, level: LogLevel, msg: &str, file: &str, function: &str, line: u32) {
+    let record = Log {
+      stamp: Time::now(),
+      level: level as u8,
+      name: self.node_name.clone(),
+      msg: msg.to_string(),
+      file: file.to_string(),
+      function: function.to_string(),
+      line,
+    };
+    if let Err(e) = self.publisher.publish(record) {
+      log::warn!("rosout publish failed: {e}");
+    }
+  }
+
+  /// Log at [`LogLevel::Debug`] (no source location).
+  pub fn debug(&self, msg: &str) {
+    self.log_at(LogLevel::Debug, msg, "", "", 0);
+  }
+  /// Log at [`LogLevel::Info`] (no source location).
+  pub fn info(&self, msg: &str) {
+    self.log_at(LogLevel::Info, msg, "", "", 0);
+  }
+  /// Log at [`LogLevel::Warn`] (no source location).
+  pub fn warn(&self, msg: &str) {
+    self.log_at(LogLevel::Warn, msg, "", "", 0);
+  }
+  /// Log at [`LogLevel::Error`] (no source location).
+  pub fn error(&self, msg: &str) {
+    self.log_at(LogLevel::Error, msg, "", "", 0);
+  }
+  /// Log at [`LogLevel::Fatal`] (no source location).
+  pub fn fatal(&self, msg: &str) {
+    self.log_at(LogLevel::Fatal, msg, "", "", 0);
+  }
+}
+
+/// Write a record to the `/rosout` topic via a [`Logger`], capturing the call
+/// site's file and line.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[cfg(feature = "zenoh")]
+/// # fn demo(logger: &ros2_client::Logger) {
+/// use ros2_client::ros2::LogLevel;
+/// let kind = "silly";
+/// ros2_client::rosout!(logger, LogLevel::Info, "A {} event was seen.", kind);
+/// # }
+/// ```
+#[cfg(feature = "zenoh")]
+#[macro_export]
+macro_rules! rosout {
+  ($logger:expr, $lvl:expr, $($arg:tt)+) => (
+    $crate::Logger::log_at(
+      &$logger,
+      $lvl,
+      &std::format!($($arg)+),
+      std::file!(),
+      "<unknown_func>",
+      std::line!(),
+    )
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use std::time::{Duration, Instant};
+
+  use zenoh::Config;
+
+  use crate::{ros2::LogLevel, Context, ContextOptions, NodeName, NodeOptions};
+
+  fn make_config(listen_port: u16, connect_port: Option<u16>) -> Config {
+    let mut c = Config::default();
+    c.insert_json5("mode", "\"peer\"").unwrap();
+    c.insert_json5("scouting/multicast/enabled", "false")
+      .unwrap();
+    c.insert_json5(
+      "listen/endpoints",
+      &format!("[\"tcp/127.0.0.1:{listen_port}\"]"),
+    )
+    .unwrap();
+    if let Some(p) = connect_port {
+      c.insert_json5("connect/endpoints", &format!("[\"tcp/127.0.0.1:{p}\"]"))
+        .unwrap();
+    }
+    c
+  }
+
+  #[test]
+  fn rosout_publish_and_read() {
+    let pub_port = 17525;
+    let sub_port = 17526;
+    let sub_ctx =
+      Context::with_options(ContextOptions::new().zenoh_config(make_config(sub_port, None)))
+        .unwrap();
+    let pub_ctx = Context::with_options(
+      ContextOptions::new().zenoh_config(make_config(pub_port, Some(sub_port))),
+    )
+    .unwrap();
+
+    let sub_node = sub_ctx.new_node(NodeName::new("/", "listener").unwrap(), NodeOptions::new());
+    let pub_node = pub_ctx.new_node(NodeName::new("/", "talker").unwrap(), NodeOptions::new());
+
+    let reader = sub_node.read_rosout().unwrap();
+    let logger = pub_node.create_logger().unwrap();
+
+    // Publish repeatedly until the peers connect and a record arrives.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut got = None;
+    while Instant::now() < deadline {
+      rosout!(logger, LogLevel::Warn, "hello from {}", "talker");
+      if let Some((record, _info)) = reader.try_take().unwrap() {
+        got = Some(record);
+        break;
+      }
+      std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let record = got.expect("no rosout record received within timeout");
+    assert_eq!(record.level, LogLevel::Warn as u8);
+    assert_eq!(record.name, "talker");
+    assert_eq!(record.msg, "hello from talker");
+    assert!(record.file.ends_with("rosout.rs"));
+    assert!(record.line > 0);
+  }
+}

--- a/src/zenoh_backend/service.rs
+++ b/src/zenoh_backend/service.rs
@@ -1,0 +1,355 @@
+//! Zenoh services: `Client` and `Server` over queryable/get (E6).
+//!
+//! Mirrors `rmw_zenoh` (see `docs/zenoh_study/research/rmw_zenoh.md` §5 and
+//! `docs/decisions/0006-services-over-queryable-get.md`):
+//!
+//! * A **server** declares a `complete` queryable on the service key and, for
+//!   each incoming query, reads the request (CDR payload) and its attachment
+//!   `(seq, ts, client_gid)`. It stores the pending [`zenoh::query::Query`]
+//!   keyed by `(client_gid, seq)` and, when the response is ready, `reply`s
+//!   with the CDR response plus an attachment echoing the client's seq + gid.
+//! * A **client** issues a `get` on the service key (wildcard type-hash,
+//!   liberal receive) carrying the request payload + attachment, and decodes
+//!   the first OK reply.
+
+use std::{
+  collections::HashMap,
+  marker::PhantomData,
+  sync::{
+    atomic::{AtomicI64, Ordering},
+    Mutex,
+  },
+  time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::{de::DeserializeOwned, Serialize};
+use zenoh::{
+  handlers::FifoChannelHandler,
+  liveliness::LivelinessToken,
+  query::{ConsolidationMode, Query, QueryTarget, Queryable},
+  Session, Wait,
+};
+
+use super::{attachment::AttachmentData, cdr};
+
+fn now_nanos() -> i64 {
+  SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .map(|d| d.as_nanos() as i64)
+    .unwrap_or(0)
+}
+
+/// Identifies a service request: the client's GID plus its sequence number.
+/// (The Zenoh analogue of the DDS `RmwRequestId`.)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RmwRequestId {
+  /// GID of the requesting client entity.
+  pub writer_gid: [u8; 16],
+  /// Client-assigned request sequence number.
+  pub sequence_number: i64,
+}
+
+/// Errors from service calls.
+#[derive(Debug)]
+pub enum ServiceError {
+  /// CDR (de)serialization failed.
+  Cdr(cdr::CdrError),
+  /// Underlying Zenoh error.
+  Zenoh(zenoh::Error),
+  /// A received request/reply lacked the expected payload or attachment.
+  Malformed,
+  /// The client received no reply.
+  NoReply,
+  /// `send_response` referenced an unknown request id.
+  UnknownRequest,
+}
+
+impl std::fmt::Display for ServiceError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      ServiceError::Cdr(e) => write!(f, "service: {e}"),
+      ServiceError::Zenoh(e) => write!(f, "service: zenoh error: {e}"),
+      ServiceError::Malformed => write!(f, "service: malformed request/reply"),
+      ServiceError::NoReply => write!(f, "service: no reply received"),
+      ServiceError::UnknownRequest => write!(f, "service: unknown request id"),
+    }
+  }
+}
+impl std::error::Error for ServiceError {}
+
+fn gid_key(gid: [u8; 16]) -> u128 {
+  u128::from_le_bytes(gid)
+}
+
+/// A ROS 2 service client over Zenoh.
+pub struct Client<Req, Resp> {
+  session: Session,
+  /// The `get` selector (service key with a wildcard type hash).
+  selector: String,
+  seq: AtomicI64,
+  client_gid: [u8; 16],
+  _liveliness_token: Option<LivelinessToken>,
+  phantom: PhantomData<fn(Req) -> Resp>,
+}
+
+impl<Req: Serialize, Resp: DeserializeOwned> Client<Req, Resp> {
+  pub(crate) fn new(
+    session: Session,
+    selector: String,
+    client_gid: [u8; 16],
+    liveliness_token: Option<LivelinessToken>,
+  ) -> Self {
+    Self {
+      session,
+      selector,
+      seq: AtomicI64::new(0),
+      client_gid,
+      _liveliness_token: liveliness_token,
+      phantom: PhantomData,
+    }
+  }
+
+  fn request_bytes(&self, req: &Req) -> Result<(Vec<u8>, zenoh::bytes::ZBytes), ServiceError> {
+    let payload = cdr::to_cdr(req).map_err(ServiceError::Cdr)?;
+    let seq = self.seq.fetch_add(1, Ordering::Relaxed) + 1;
+    let attachment = AttachmentData {
+      sequence_number: seq,
+      source_timestamp: now_nanos(),
+      source_gid: self.client_gid,
+    }
+    .to_zbytes();
+    Ok((payload, attachment))
+  }
+
+  fn decode_reply(reply: &zenoh::query::Reply) -> Option<Result<Resp, ServiceError>> {
+    let sample = reply.result().ok()?;
+    let bytes = sample.payload().to_bytes();
+    Some(cdr::from_cdr::<Resp>(&bytes).map_err(ServiceError::Cdr))
+  }
+
+  /// Call the service and wait (blocking) for the first reply.
+  pub fn call(&self, req: Req) -> Result<Resp, ServiceError> {
+    let (payload, attachment) = self.request_bytes(&req)?;
+    let replies = self
+      .session
+      .get(&self.selector)
+      .payload(payload)
+      .attachment(attachment)
+      .target(QueryTarget::AllComplete)
+      .consolidation(ConsolidationMode::None)
+      .wait()
+      .map_err(ServiceError::Zenoh)?;
+    while let Ok(reply) = replies.recv() {
+      if let Some(res) = Self::decode_reply(&reply) {
+        return res;
+      }
+    }
+    Err(ServiceError::NoReply)
+  }
+
+  /// Call the service and await the first reply.
+  pub async fn async_call(&self, req: Req) -> Result<Resp, ServiceError> {
+    let (payload, attachment) = self.request_bytes(&req)?;
+    let replies = self
+      .session
+      .get(&self.selector)
+      .payload(payload)
+      .attachment(attachment)
+      .target(QueryTarget::AllComplete)
+      .consolidation(ConsolidationMode::None)
+      .await
+      .map_err(ServiceError::Zenoh)?;
+    while let Ok(reply) = replies.recv_async().await {
+      if let Some(res) = Self::decode_reply(&reply) {
+        return res;
+      }
+    }
+    Err(ServiceError::NoReply)
+  }
+}
+
+/// A ROS 2 service server over Zenoh.
+pub struct Server<Req, Resp> {
+  queryable: Queryable<FifoChannelHandler<Query>>,
+  pending: Mutex<HashMap<(u128, i64), Query>>,
+  _liveliness_token: Option<LivelinessToken>,
+  phantom: PhantomData<fn(Req) -> Resp>,
+}
+
+impl<Req: DeserializeOwned, Resp: Serialize> Server<Req, Resp> {
+  pub(crate) fn new(
+    queryable: Queryable<FifoChannelHandler<Query>>,
+    liveliness_token: Option<LivelinessToken>,
+  ) -> Self {
+    Self {
+      queryable,
+      pending: Mutex::new(HashMap::new()),
+      _liveliness_token: liveliness_token,
+      phantom: PhantomData,
+    }
+  }
+
+  fn accept(&self, query: Query) -> Result<(RmwRequestId, Req), ServiceError> {
+    let payload = query.payload().ok_or(ServiceError::Malformed)?;
+    let req = cdr::from_cdr::<Req>(&payload.to_bytes()).map_err(ServiceError::Cdr)?;
+    let attachment = query.attachment().ok_or(ServiceError::Malformed)?;
+    let a = AttachmentData::from_zbytes(attachment).map_err(|_| ServiceError::Malformed)?;
+    let id = RmwRequestId {
+      writer_gid: a.source_gid,
+      sequence_number: a.sequence_number,
+    };
+    self
+      .pending
+      .lock()
+      .unwrap()
+      .insert((gid_key(a.source_gid), a.sequence_number), query);
+    Ok((id, req))
+  }
+
+  /// Take the next pending request if one is immediately available.
+  pub fn try_receive_request(&self) -> Result<Option<(RmwRequestId, Req)>, ServiceError> {
+    match self.queryable.try_recv() {
+      Ok(Some(query)) => self.accept(query).map(Some),
+      Ok(None) => Ok(None),
+      Err(_) => Ok(None),
+    }
+  }
+
+  /// Await the next request.
+  pub async fn async_receive_request(&self) -> Result<(RmwRequestId, Req), ServiceError> {
+    let query = self
+      .queryable
+      .recv_async()
+      .await
+      .map_err(|_| ServiceError::NoReply)?;
+    self.accept(query)
+  }
+
+  /// Send the response for a previously received request.
+  pub fn send_response(&self, id: RmwRequestId, resp: Resp) -> Result<(), ServiceError> {
+    let query = self
+      .pending
+      .lock()
+      .unwrap()
+      .remove(&(gid_key(id.writer_gid), id.sequence_number))
+      .ok_or(ServiceError::UnknownRequest)?;
+    let payload = cdr::to_cdr(&resp).map_err(ServiceError::Cdr)?;
+    // Echo the request's seq + client gid; fresh reply timestamp.
+    let attachment = AttachmentData {
+      sequence_number: id.sequence_number,
+      source_timestamp: now_nanos(),
+      source_gid: id.writer_gid,
+    }
+    .to_zbytes();
+    query
+      .reply(query.key_expr().clone(), payload)
+      .attachment(attachment)
+      .wait()
+      .map_err(ServiceError::Zenoh)?;
+    Ok(())
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use std::{
+    sync::{
+      atomic::{AtomicBool, Ordering},
+      Arc,
+    },
+    time::{Duration, Instant},
+  };
+
+  use serde::{Deserialize, Serialize};
+  use zenoh::Config;
+
+  use super::{Client, Server};
+  use crate::{Context, ContextOptions, Name, NodeName, NodeOptions, ServiceTypeName};
+
+  #[derive(Serialize, Deserialize)]
+  struct AddTwoIntsRequest {
+    a: i64,
+    b: i64,
+  }
+  #[derive(Serialize, Deserialize)]
+  struct AddTwoIntsResponse {
+    sum: i64,
+  }
+
+  fn make_config(listen_port: u16, connect_port: Option<u16>) -> Config {
+    let mut c = Config::default();
+    c.insert_json5("mode", "\"peer\"").unwrap();
+    c.insert_json5("scouting/multicast/enabled", "false")
+      .unwrap();
+    c.insert_json5(
+      "listen/endpoints",
+      &format!("[\"tcp/127.0.0.1:{listen_port}\"]"),
+    )
+    .unwrap();
+    if let Some(p) = connect_port {
+      c.insert_json5("connect/endpoints", &format!("[\"tcp/127.0.0.1:{p}\"]"))
+        .unwrap();
+    }
+    c
+  }
+
+  #[test]
+  fn add_two_ints_roundtrip() {
+    let srv_port = 17519;
+    let cli_port = 17520;
+    let srv_ctx =
+      Context::with_options(ContextOptions::new().zenoh_config(make_config(srv_port, None)))
+        .unwrap();
+    let cli_ctx = Context::with_options(
+      ContextOptions::new().zenoh_config(make_config(cli_port, Some(srv_port))),
+    )
+    .unwrap();
+
+    let srv_node = srv_ctx.new_node(
+      NodeName::new("/", "add_server").unwrap(),
+      NodeOptions::new(),
+    );
+    let cli_node = cli_ctx.new_node(
+      NodeName::new("/", "add_client").unwrap(),
+      NodeOptions::new(),
+    );
+    let stype = ServiceTypeName::new("example_interfaces", "AddTwoInts");
+    let name = Name::new("/", "add_two_ints").unwrap();
+
+    let server: Server<AddTwoIntsRequest, AddTwoIntsResponse> =
+      srv_node.create_server(&name, &stype).unwrap();
+    let client: Client<AddTwoIntsRequest, AddTwoIntsResponse> =
+      cli_node.create_client(&name, &stype).unwrap();
+
+    // Run the server in a background thread: answer requests with a + b.
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_srv = stop.clone();
+    let server_thread = std::thread::spawn(move || {
+      let deadline = Instant::now() + Duration::from_secs(25);
+      while !stop_srv.load(Ordering::Relaxed) && Instant::now() < deadline {
+        if let Ok(Some((id, req))) = server.try_receive_request() {
+          let _ = server.send_response(id, AddTwoIntsResponse { sum: req.a + req.b });
+        }
+        std::thread::sleep(Duration::from_millis(20));
+      }
+    });
+
+    // Retry the call until the peers connect and the queryable is discovered.
+    let deadline = Instant::now() + Duration::from_secs(25);
+    let mut sum = None;
+    while Instant::now() < deadline {
+      if let Ok(resp) = client.call(AddTwoIntsRequest { a: 2, b: 40 }) {
+        sum = Some(resp.sum);
+        break;
+      }
+      std::thread::sleep(Duration::from_millis(200));
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = server_thread.join();
+
+    assert_eq!(sum, Some(42));
+  }
+}

--- a/src/zenoh_backend/service.rs
+++ b/src/zenoh_backend/service.rs
@@ -84,10 +84,12 @@ fn gid_key(gid: [u8; 16]) -> u128 {
 /// A ROS 2 service client over Zenoh.
 pub struct Client<Req, Resp> {
   session: Session,
-  /// The `get` selector (service key with a wildcard type hash).
+  /// The `get` selector (concrete service key).
   selector: String,
   seq: AtomicI64,
   client_gid: [u8; 16],
+  /// Optional `get` timeout override (actions' `get_result` uses a long one).
+  timeout: Option<std::time::Duration>,
   _liveliness_token: Option<LivelinessToken>,
   phantom: PhantomData<fn(Req) -> Resp>,
 }
@@ -99,11 +101,22 @@ impl<Req: Serialize, Resp: DeserializeOwned> Client<Req, Resp> {
     client_gid: [u8; 16],
     liveliness_token: Option<LivelinessToken>,
   ) -> Self {
+    Self::new_with_timeout(session, selector, client_gid, liveliness_token, None)
+  }
+
+  pub(crate) fn new_with_timeout(
+    session: Session,
+    selector: String,
+    client_gid: [u8; 16],
+    liveliness_token: Option<LivelinessToken>,
+    timeout: Option<std::time::Duration>,
+  ) -> Self {
     Self {
       session,
       selector,
       seq: AtomicI64::new(0),
       client_gid,
+      timeout,
       _liveliness_token: liveliness_token,
       phantom: PhantomData,
     }
@@ -130,15 +143,17 @@ impl<Req: Serialize, Resp: DeserializeOwned> Client<Req, Resp> {
   /// Call the service and wait (blocking) for the first reply.
   pub fn call(&self, req: Req) -> Result<Resp, ServiceError> {
     let (payload, attachment) = self.request_bytes(&req)?;
-    let replies = self
+    let mut builder = self
       .session
       .get(&self.selector)
       .payload(payload)
       .attachment(attachment)
       .target(QueryTarget::AllComplete)
-      .consolidation(ConsolidationMode::None)
-      .wait()
-      .map_err(ServiceError::Zenoh)?;
+      .consolidation(ConsolidationMode::None);
+    if let Some(t) = self.timeout {
+      builder = builder.timeout(t);
+    }
+    let replies = builder.wait().map_err(ServiceError::Zenoh)?;
     while let Ok(reply) = replies.recv() {
       if let Some(res) = Self::decode_reply(&reply) {
         return res;
@@ -150,15 +165,17 @@ impl<Req: Serialize, Resp: DeserializeOwned> Client<Req, Resp> {
   /// Call the service and await the first reply.
   pub async fn async_call(&self, req: Req) -> Result<Resp, ServiceError> {
     let (payload, attachment) = self.request_bytes(&req)?;
-    let replies = self
+    let mut builder = self
       .session
       .get(&self.selector)
       .payload(payload)
       .attachment(attachment)
       .target(QueryTarget::AllComplete)
-      .consolidation(ConsolidationMode::None)
-      .await
-      .map_err(ServiceError::Zenoh)?;
+      .consolidation(ConsolidationMode::None);
+    if let Some(t) = self.timeout {
+      builder = builder.timeout(t);
+    }
+    let replies = builder.await.map_err(ServiceError::Zenoh)?;
     while let Ok(reply) = replies.recv_async().await {
       if let Some(res) = Self::decode_reply(&reply) {
         return res;

--- a/src/zenoh_backend/type_description.rs
+++ b/src/zenoh_backend/type_description.rs
@@ -1,0 +1,455 @@
+//! REP-2016 type descriptions and `RIHS01_…` hashing (ADR-0007).
+//!
+//! A ROS 2 type hash is `RIHS01_` + the lowercase-hex SHA-256 of a canonical
+//! JSON serialization of the type's [`TypeDescription`]. This module implements
+//! that computation exactly as `rosidl_generator_type_description`'s
+//! `calculate_type_hash` does, so a hash computed here matches the one a C++
+//! peer embeds in its Zenoh keys.
+//!
+//! It removes the send-direction limitation of the hard-coded
+//! [`super::type_hash`] table *for any type whose full field description is
+//! available*: build the [`TypeDescription`] (message, or a service via
+//! [`service_type_description`]) and call [`TypeDescription::rihs01`]. Wiring
+//! this into `msggen` so generated types carry their computed hash — which
+//! needs cross-package IDL resolution and a pinned distro's builtin
+//! definitions — is the remaining follow-up (ADR-0007).
+//!
+//! The module is backend-neutral (no `zenoh` crate) and unit-tested against the
+//! published hashes of `std_msgs/msg/String` and
+//! `example_interfaces/srv/AddTwoInts`.
+
+use sha2::{Digest, Sha256};
+
+/// `type_description_interfaces/msg/FieldType` `type_id` constants.
+///
+/// The base (scalar) ids are 1..=22. Array / bounded-sequence /
+/// unbounded-sequence variants of a base id `b` are `b + 48`, `b + 96`,
+/// `b + 144` respectively.
+pub mod type_id {
+  /// No type set.
+  pub const NOT_SET: u8 = 0;
+  /// A nested (named) type.
+  pub const NESTED_TYPE: u8 = 1;
+  /// `int8`.
+  pub const INT8: u8 = 2;
+  /// `uint8`.
+  pub const UINT8: u8 = 3;
+  /// `int16`.
+  pub const INT16: u8 = 4;
+  /// `uint16`.
+  pub const UINT16: u8 = 5;
+  /// `int32`.
+  pub const INT32: u8 = 6;
+  /// `uint32`.
+  pub const UINT32: u8 = 7;
+  /// `int64`.
+  pub const INT64: u8 = 8;
+  /// `uint64`.
+  pub const UINT64: u8 = 9;
+  /// `float`.
+  pub const FLOAT: u8 = 10;
+  /// `double`.
+  pub const DOUBLE: u8 = 11;
+  /// `long double`.
+  pub const LONG_DOUBLE: u8 = 12;
+  /// `char`.
+  pub const CHAR: u8 = 13;
+  /// `wchar`.
+  pub const WCHAR: u8 = 14;
+  /// `bool`.
+  pub const BOOLEAN: u8 = 15;
+  /// `byte`.
+  pub const BYTE: u8 = 16;
+  /// `string`.
+  pub const STRING: u8 = 17;
+  /// `wstring`.
+  pub const WSTRING: u8 = 18;
+  /// `string<=N` fixed (unused by the current rosidl parser).
+  pub const FIXED_STRING: u8 = 19;
+  /// `wstring<=N` fixed (unused by the current rosidl parser).
+  pub const FIXED_WSTRING: u8 = 20;
+  /// Bounded `string<=N`.
+  pub const BOUNDED_STRING: u8 = 21;
+  /// Bounded `wstring<=N`.
+  pub const BOUNDED_WSTRING: u8 = 22;
+
+  /// Offset added to a base id for a fixed-size array variant.
+  pub const ARRAY_OFFSET: u8 = 48;
+  /// Offset added to a base id for a bounded-sequence variant.
+  pub const BOUNDED_SEQUENCE_OFFSET: u8 = 96;
+  /// Offset added to a base id for an unbounded-sequence variant.
+  pub const UNBOUNDED_SEQUENCE_OFFSET: u8 = 144;
+}
+
+/// A `type_description_interfaces/msg/FieldType`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FieldType {
+  /// The `FIELD_TYPE_*` id (see [`type_id`]).
+  pub type_id: u8,
+  /// Fixed-array length or bounded-sequence max (else 0).
+  pub capacity: u64,
+  /// Fixed/bounded (w)string length or max (else 0).
+  pub string_capacity: u64,
+  /// `/`-joined name of the nested type (else empty).
+  pub nested_type_name: String,
+}
+
+impl FieldType {
+  /// A scalar of the given base [`type_id`].
+  pub fn scalar(type_id: u8) -> Self {
+    Self {
+      type_id,
+      capacity: 0,
+      string_capacity: 0,
+      nested_type_name: String::new(),
+    }
+  }
+
+  /// A fixed-size array `[capacity]` of the given base scalar id.
+  pub fn array(base_type_id: u8, capacity: u64) -> Self {
+    Self {
+      type_id: base_type_id + type_id::ARRAY_OFFSET,
+      capacity,
+      string_capacity: 0,
+      nested_type_name: String::new(),
+    }
+  }
+
+  /// A reference to a nested (named) type.
+  pub fn nested(name: impl Into<String>) -> Self {
+    Self {
+      type_id: type_id::NESTED_TYPE,
+      capacity: 0,
+      string_capacity: 0,
+      nested_type_name: name.into(),
+    }
+  }
+
+  /// A bounded sequence `[<=capacity]` of a nested (named) type.
+  pub fn nested_bounded_sequence(name: impl Into<String>, capacity: u64) -> Self {
+    Self {
+      type_id: type_id::NESTED_TYPE + type_id::BOUNDED_SEQUENCE_OFFSET,
+      capacity,
+      string_capacity: 0,
+      nested_type_name: name.into(),
+    }
+  }
+}
+
+/// A `type_description_interfaces/msg/Field`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Field {
+  /// Field name.
+  pub name: String,
+  /// Field type.
+  pub field_type: FieldType,
+  /// Literal default value (stripped before hashing; kept for completeness).
+  pub default_value: String,
+}
+
+impl Field {
+  /// A field with no default value.
+  pub fn new(name: impl Into<String>, field_type: FieldType) -> Self {
+    Self {
+      name: name.into(),
+      field_type,
+      default_value: String::new(),
+    }
+  }
+}
+
+/// A `type_description_interfaces/msg/IndividualTypeDescription`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IndividualTypeDescription {
+  /// `/`-joined namespaced type name (e.g. `std_msgs/msg/String`).
+  pub type_name: String,
+  /// Ordered fields.
+  pub fields: Vec<Field>,
+}
+
+impl IndividualTypeDescription {
+  /// New description from a name and fields.
+  pub fn new(type_name: impl Into<String>, fields: Vec<Field>) -> Self {
+    Self {
+      type_name: type_name.into(),
+      fields,
+    }
+  }
+}
+
+/// A `type_description_interfaces/msg/TypeDescription`: the top type plus the
+/// transitive closure of the nested types it references.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeDescription {
+  /// The type being described.
+  pub type_description: IndividualTypeDescription,
+  /// The transitive closure of referenced nested types (any order; hashing
+  /// sorts them by name).
+  pub referenced_type_descriptions: Vec<IndividualTypeDescription>,
+}
+
+impl TypeDescription {
+  /// New description.
+  pub fn new(
+    type_description: IndividualTypeDescription,
+    referenced_type_descriptions: Vec<IndividualTypeDescription>,
+  ) -> Self {
+    Self {
+      type_description,
+      referenced_type_descriptions,
+    }
+  }
+
+  /// The canonical hashable JSON representation (matches
+  /// `calculate_type_hash`'s `json.dumps(..., separators=(', ', ': '))` with
+  /// `default_value` stripped and referenced types sorted by name).
+  pub fn hashable_json(&self) -> String {
+    let mut refs: Vec<&IndividualTypeDescription> =
+      self.referenced_type_descriptions.iter().collect();
+    refs.sort_by(|a, b| a.type_name.cmp(&b.type_name));
+
+    let mut out = String::new();
+    out.push_str("{\"type_description\": ");
+    write_itd(&self.type_description, &mut out);
+    out.push_str(", \"referenced_type_descriptions\": [");
+    for (i, itd) in refs.iter().enumerate() {
+      if i > 0 {
+        out.push_str(", ");
+      }
+      write_itd(itd, &mut out);
+    }
+    out.push_str("]}");
+    out
+  }
+
+  /// The REP-2016 type hash string, `RIHS01_` + lowercase-hex SHA-256 of
+  /// [`hashable_json`](Self::hashable_json).
+  pub fn rihs01(&self) -> String {
+    let json = self.hashable_json();
+    let digest = Sha256::digest(json.as_bytes());
+    let mut s = String::with_capacity(71);
+    s.push_str("RIHS01_");
+    for b in digest {
+      s.push_str(&format!("{b:02x}"));
+    }
+    s
+  }
+}
+
+/// Compose the `TypeDescription` of a service from its already-built request,
+/// response, and event individual descriptions plus their referenced closure,
+/// mirroring `rosidl_generator_type_description`'s `add_srv`.
+///
+/// The synthetic top type is named `<service_name>` (no suffix) with fields
+/// `request_message`, `response_message`, `event_message` referencing
+/// `<service_name>_Request` / `_Response` / `_Event`. The three individual
+/// descriptions and every entry in `referenced` become the referenced closure.
+pub fn service_type_description(
+  service_name: &str,
+  request: IndividualTypeDescription,
+  response: IndividualTypeDescription,
+  event: IndividualTypeDescription,
+  referenced: Vec<IndividualTypeDescription>,
+) -> TypeDescription {
+  let top = IndividualTypeDescription::new(
+    service_name.to_string(),
+    vec![
+      Field::new(
+        "request_message",
+        FieldType::nested(format!("{service_name}_Request")),
+      ),
+      Field::new(
+        "response_message",
+        FieldType::nested(format!("{service_name}_Response")),
+      ),
+      Field::new(
+        "event_message",
+        FieldType::nested(format!("{service_name}_Event")),
+      ),
+    ],
+  );
+  let mut refs = vec![request, response, event];
+  refs.extend(referenced);
+  TypeDescription::new(top, refs)
+}
+
+// --- canonical JSON writers ------------------------------------------------
+
+fn write_itd(itd: &IndividualTypeDescription, out: &mut String) {
+  out.push_str("{\"type_name\": ");
+  write_json_string(&itd.type_name, out);
+  out.push_str(", \"fields\": [");
+  for (i, f) in itd.fields.iter().enumerate() {
+    if i > 0 {
+      out.push_str(", ");
+    }
+    write_field(f, out);
+  }
+  out.push_str("]}");
+}
+
+fn write_field(f: &Field, out: &mut String) {
+  // `default_value` is stripped before hashing.
+  out.push_str("{\"name\": ");
+  write_json_string(&f.name, out);
+  out.push_str(", \"type\": ");
+  write_field_type(&f.field_type, out);
+  out.push('}');
+}
+
+fn write_field_type(ft: &FieldType, out: &mut String) {
+  out.push_str("{\"type_id\": ");
+  out.push_str(&ft.type_id.to_string());
+  out.push_str(", \"capacity\": ");
+  out.push_str(&ft.capacity.to_string());
+  out.push_str(", \"string_capacity\": ");
+  out.push_str(&ft.string_capacity.to_string());
+  out.push_str(", \"nested_type_name\": ");
+  write_json_string(&ft.nested_type_name, out);
+  out.push('}');
+}
+
+/// Write `s` as a JSON string with `ensure_ascii=True` semantics (matching
+/// Python's `json.dumps`): named escapes for the common control chars,
+/// `\uXXXX` for other control chars and all non-ASCII (UTF-16 code units).
+fn write_json_string(s: &str, out: &mut String) {
+  out.push('"');
+  for c in s.chars() {
+    match c {
+      '"' => out.push_str("\\\""),
+      '\\' => out.push_str("\\\\"),
+      '\n' => out.push_str("\\n"),
+      '\r' => out.push_str("\\r"),
+      '\t' => out.push_str("\\t"),
+      '\u{08}' => out.push_str("\\b"),
+      '\u{0c}' => out.push_str("\\f"),
+      c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+      c if c.is_ascii() => out.push(c),
+      c => {
+        let mut buf = [0u16; 2];
+        for unit in c.encode_utf16(&mut buf) {
+          out.push_str(&format!("\\u{unit:04x}"));
+        }
+      }
+    }
+  }
+  out.push('"');
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use super::{type_id as t, *};
+
+  #[test]
+  fn std_msgs_string_hash_matches() {
+    // std_msgs/msg/String: single `string data` field, no referenced types.
+    let td = TypeDescription::new(
+      IndividualTypeDescription::new(
+        "std_msgs/msg/String",
+        vec![Field::new("data", FieldType::scalar(t::STRING))],
+      ),
+      vec![],
+    );
+
+    assert_eq!(
+      td.hashable_json(),
+      "{\"type_description\": {\"type_name\": \"std_msgs/msg/String\", \"fields\": \
+       [{\"name\": \"data\", \"type\": {\"type_id\": 17, \"capacity\": 0, \
+       \"string_capacity\": 0, \"nested_type_name\": \"\"}}]}, \
+       \"referenced_type_descriptions\": []}"
+    );
+    assert_eq!(
+      td.rihs01(),
+      "RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18"
+    );
+    // The pure algorithm reproduces the value baked into the known-types table.
+    assert_eq!(
+      td.rihs01(),
+      super::super::type_hash::known_type_hash("std_msgs::msg::dds_::String_").unwrap()
+    );
+  }
+
+  #[test]
+  fn add_two_ints_service_hash_matches() {
+    let svc = "example_interfaces/srv/AddTwoInts";
+
+    let request = IndividualTypeDescription::new(
+      format!("{svc}_Request"),
+      vec![
+        Field::new("a", FieldType::scalar(t::INT64)),
+        Field::new("b", FieldType::scalar(t::INT64)),
+      ],
+    );
+    let response = IndividualTypeDescription::new(
+      format!("{svc}_Response"),
+      vec![Field::new("sum", FieldType::scalar(t::INT64))],
+    );
+    let event = IndividualTypeDescription::new(
+      format!("{svc}_Event"),
+      vec![
+        Field::new(
+          "info",
+          FieldType::nested("service_msgs/msg/ServiceEventInfo"),
+        ),
+        Field::new(
+          "request",
+          FieldType::nested_bounded_sequence(format!("{svc}_Request"), 1),
+        ),
+        Field::new(
+          "response",
+          FieldType::nested_bounded_sequence(format!("{svc}_Response"), 1),
+        ),
+      ],
+    );
+
+    // Transitive closure (order irrelevant — hashing sorts by name).
+    let time = IndividualTypeDescription::new(
+      "builtin_interfaces/msg/Time",
+      vec![
+        Field::new("sec", FieldType::scalar(t::INT32)),
+        Field::new("nanosec", FieldType::scalar(t::UINT32)),
+      ],
+    );
+    // NOTE: this hash corresponds to the ROS distro where ServiceEventInfo's
+    // `client_gid` is `uint8[16]` (type_id 51). Newer `char[16]` distros hash
+    // differently.
+    let service_event_info = IndividualTypeDescription::new(
+      "service_msgs/msg/ServiceEventInfo",
+      vec![
+        Field::new("event_type", FieldType::scalar(t::UINT8)),
+        Field::new("stamp", FieldType::nested("builtin_interfaces/msg/Time")),
+        Field::new("client_gid", FieldType::array(t::UINT8, 16)),
+        Field::new("sequence_number", FieldType::scalar(t::INT64)),
+      ],
+    );
+
+    let td = service_type_description(
+      svc,
+      request.clone(),
+      response.clone(),
+      event.clone(),
+      vec![time, service_event_info],
+    );
+
+    assert_eq!(
+      td.rihs01(),
+      "RIHS01_e118de6bf5eeb66a2491b5bda11202e7b68f198d6f67922cf30364858239c81a"
+    );
+    assert_eq!(
+      td.rihs01(),
+      super::super::type_hash::known_type_hash("example_interfaces::srv::dds_::AddTwoInts_")
+        .unwrap()
+    );
+  }
+
+  #[test]
+  fn field_type_offsets() {
+    assert_eq!(FieldType::array(t::UINT8, 16).type_id, 51);
+    assert_eq!(
+      FieldType::nested_bounded_sequence("x", 1).type_id,
+      t::NESTED_TYPE + t::BOUNDED_SEQUENCE_OFFSET
+    );
+  }
+}

--- a/src/zenoh_backend/type_hash.rs
+++ b/src/zenoh_backend/type_hash.rs
@@ -22,6 +22,14 @@
 /// one key-expression chunk (the hash), which is what we want here.
 pub const WILDCARD: &str = "*";
 
+/// Concrete placeholder hash used by a *sender* (publisher/client) when the
+/// real REP-2016 hash is unknown. A `put` cannot target a wildcard key, so a
+/// concrete value is required; this well-formed all-zero `RIHS01_` hash lets
+/// two `ros2-client` peers match each other. Interop with C++ peers in the send
+/// direction still needs the real hash (see [`known_type_hash`], ADR-0007).
+pub const PLACEHOLDER_HASH: &str =
+  "RIHS01_0000000000000000000000000000000000000000000000000000000000000000";
+
 /// Look up the REP-2016 type hash for a DDS-form type name
 /// (e.g. `std_msgs::msg::dds_::String_`).
 ///
@@ -39,10 +47,11 @@ pub fn known_type_hash(dds_type_name: &str) -> Option<&'static str> {
   })
 }
 
-/// The hash to place in a *sender's* key: the known hash if we have it,
-/// otherwise a placeholder wildcard (documented limitation).
+/// The hash to place in a *sender's* (publisher/client) concrete key: the known
+/// hash if we have it, otherwise [`PLACEHOLDER_HASH`] (documented limitation —
+/// send-direction interop with C++ peers needs the real hash).
 pub fn sender_hash(dds_type_name: &str) -> &str {
-  known_type_hash(dds_type_name).unwrap_or(WILDCARD)
+  known_type_hash(dds_type_name).unwrap_or(PLACEHOLDER_HASH)
 }
 
 // ---------------------------------------------------------------------------
@@ -64,9 +73,11 @@ mod tests {
   }
 
   #[test]
-  fn unknown_falls_back_to_wildcard() {
+  fn unknown_sender_uses_concrete_placeholder() {
     assert_eq!(known_type_hash("pkg::msg::dds_::Nope_"), None);
-    assert_eq!(sender_hash("pkg::msg::dds_::Nope_"), WILDCARD);
+    // A sender must use a concrete key, never the wildcard.
+    assert_eq!(sender_hash("pkg::msg::dds_::Nope_"), PLACEHOLDER_HASH);
+    assert_ne!(sender_hash("pkg::msg::dds_::Nope_"), WILDCARD);
     assert!(sender_hash("std_msgs::msg::dds_::String_").starts_with("RIHS01_"));
   }
 }

--- a/src/zenoh_backend/type_hash.rs
+++ b/src/zenoh_backend/type_hash.rs
@@ -10,9 +10,9 @@
 //!   [`WILDCARD`] in the hash slot, so they receive from any publisher/client
 //!   regardless of hash.
 //! * **Senders** look up a correct hash from the [`known_type_hash`] table for
-//!   the common interop types; unknown types fall back to a wildcard/placeholder
-//!   and send-direction interop with C++ peers may not match until full IDL
-//!   hashing lands.
+//!   the common interop types; unknown types fall back to a
+//!   wildcard/placeholder and send-direction interop with C++ peers may not
+//!   match until full IDL hashing lands.
 //!
 //! The table values are taken from observed `rmw_zenoh` traffic / the design
 //! examples and are covered by a test so drift is caught.

--- a/src/zenoh_backend/type_hash.rs
+++ b/src/zenoh_backend/type_hash.rs
@@ -15,7 +15,13 @@
 //!   match until full IDL hashing lands.
 //!
 //! The table values are taken from observed `rmw_zenoh` traffic / the design
-//! examples and are covered by a test so drift is caught.
+//! examples and are covered by a test so drift is caught. They are additionally
+//! cross-checked against the from-scratch REP-2016 computation in
+//! [`super::type_description`] (which reproduces both hashes byte-exactly from
+//! their field descriptions), so the table entries are now *verified* rather
+//! than merely observed. Computing hashes for arbitrary types at code-gen time
+//! (removing the table entirely for the send direction) is the remaining
+//! `msggen` integration follow-up (ADR-0007).
 
 /// Wildcard used in the type-hash slot of a *receiver's* key expression so it
 /// matches publishers/clients of any hash. A single-chunk `*` matches exactly

--- a/src/zenoh_backend/type_hash.rs
+++ b/src/zenoh_backend/type_hash.rs
@@ -36,21 +36,59 @@ pub const WILDCARD: &str = "*";
 pub const PLACEHOLDER_HASH: &str =
   "RIHS01_0000000000000000000000000000000000000000000000000000000000000000";
 
+lazy_static::lazy_static! {
+  /// `dds_type_name -> RIHS01_…` for the `std_msgs` scalar message types a
+  /// device bridge publishes (`Float64`, `Bool`, `Int32`, …). Each is a single
+  /// `data` field, so its REP-2016 hash is computed from that description via
+  /// [`super::type_description`] — exactly (byte-for-byte) as a C++ peer would —
+  /// so *native* scalar topics match on the **send** direction, without waiting
+  /// on the full `msggen` integration (ADR-0007). `String` stays in the
+  /// hard-coded table in [`known_type_hash`].
+  static ref STD_MSGS_SCALAR_HASHES: std::collections::HashMap<&'static str, String> = {
+    use super::type_description::{
+      type_id as t, Field, FieldType, IndividualTypeDescription, TypeDescription,
+    };
+    // (DDS type name, ROS type name, the `data` field's base type id)
+    let scalars: &[(&str, &str, u8)] = &[
+      ("std_msgs::msg::dds_::Bool_", "std_msgs/msg/Bool", t::BOOLEAN),
+      ("std_msgs::msg::dds_::Float32_", "std_msgs/msg/Float32", t::FLOAT),
+      ("std_msgs::msg::dds_::Float64_", "std_msgs/msg/Float64", t::DOUBLE),
+      ("std_msgs::msg::dds_::Int32_", "std_msgs/msg/Int32", t::INT32),
+      ("std_msgs::msg::dds_::Int64_", "std_msgs/msg/Int64", t::INT64),
+      ("std_msgs::msg::dds_::UInt32_", "std_msgs/msg/UInt32", t::UINT32),
+      ("std_msgs::msg::dds_::UInt64_", "std_msgs/msg/UInt64", t::UINT64),
+    ];
+    scalars
+      .iter()
+      .map(|&(dds, ros, tid)| {
+        let td = TypeDescription::new(
+          IndividualTypeDescription::new(ros, vec![Field::new("data", FieldType::scalar(tid))]),
+          Vec::new(),
+        );
+        (dds, td.rihs01())
+      })
+      .collect()
+  };
+}
+
 /// Look up the REP-2016 type hash for a DDS-form type name
 /// (e.g. `std_msgs::msg::dds_::String_`).
 ///
-/// Returns `None` for types not in the table; callers then fall back to a
-/// wildcard/placeholder for the send direction.
+/// Covers the hard-coded interop types plus the computed `std_msgs` scalar
+/// messages ([`STD_MSGS_SCALAR_HASHES`]). Returns `None` for anything else;
+/// callers then fall back to a wildcard/placeholder for the send direction.
 pub fn known_type_hash(dds_type_name: &str) -> Option<&'static str> {
-  Some(match dds_type_name {
+  match dds_type_name {
     "std_msgs::msg::dds_::String_" => {
-      "RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18"
+      Some("RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18")
     }
     "example_interfaces::srv::dds_::AddTwoInts_" => {
-      "RIHS01_e118de6bf5eeb66a2491b5bda11202e7b68f198d6f67922cf30364858239c81a"
+      Some("RIHS01_e118de6bf5eeb66a2491b5bda11202e7b68f198d6f67922cf30364858239c81a")
     }
-    _ => return None,
-  })
+    _ => STD_MSGS_SCALAR_HASHES
+      .get(dds_type_name)
+      .map(String::as_str),
+  }
 }
 
 /// The hash to place in a *sender's* (publisher/client) concrete key: the known
@@ -85,5 +123,43 @@ mod tests {
     assert_eq!(sender_hash("pkg::msg::dds_::Nope_"), PLACEHOLDER_HASH);
     assert_ne!(sender_hash("pkg::msg::dds_::Nope_"), WILDCARD);
     assert!(sender_hash("std_msgs::msg::dds_::String_").starts_with("RIHS01_"));
+  }
+
+  #[test]
+  fn std_msgs_scalars_have_computed_hashes() {
+    use super::super::type_description::{
+      type_id as t, Field, FieldType, IndividualTypeDescription, TypeDescription,
+    };
+
+    // Float64 (and the other scalars) are now known and well-formed.
+    let f64_hash = known_type_hash("std_msgs::msg::dds_::Float64_").expect("Float64 known");
+    assert!(f64_hash.starts_with("RIHS01_") && f64_hash.len() == 71);
+    for dds in [
+      "std_msgs::msg::dds_::Bool_",
+      "std_msgs::msg::dds_::Float32_",
+      "std_msgs::msg::dds_::Int32_",
+      "std_msgs::msg::dds_::Int64_",
+      "std_msgs::msg::dds_::UInt32_",
+      "std_msgs::msg::dds_::UInt64_",
+    ] {
+      assert!(known_type_hash(dds).is_some(), "{dds} should be known");
+    }
+
+    // The table value equals the hash computed straight from the field
+    // description (drift guard, mirroring the String cross-check).
+    let td = TypeDescription::new(
+      IndividualTypeDescription::new(
+        "std_msgs/msg/Float64",
+        vec![Field::new("data", FieldType::scalar(t::DOUBLE))],
+      ),
+      Vec::new(),
+    );
+    assert_eq!(
+      known_type_hash("std_msgs::msg::dds_::Float64_"),
+      Some(td.rihs01().as_str())
+    );
+
+    // A genuinely unknown type is still None.
+    assert_eq!(known_type_hash("pkg::msg::dds_::Nope_"), None);
   }
 }

--- a/src/zenoh_backend/type_hash.rs
+++ b/src/zenoh_backend/type_hash.rs
@@ -1,0 +1,72 @@
+//! REP-2016 type hashes (`RIHS01_…`) for the Zenoh key-expression scheme.
+//!
+//! `rmw_zenoh` embeds a type hash in every topic/service key and liveliness
+//! token; two entities match only if name **and** type **and** hash agree.
+//! `ros2-client` does not yet compute REP-2016 hashes from IDL, so — per
+//! `docs/decisions/0007-type-hash-interop-strategy.md` — we use a layered
+//! strategy:
+//!
+//! * **Receivers** (subscriptions, queryables) build their key with
+//!   [`WILDCARD`] in the hash slot, so they receive from any publisher/client
+//!   regardless of hash.
+//! * **Senders** look up a correct hash from the [`known_type_hash`] table for
+//!   the common interop types; unknown types fall back to a wildcard/placeholder
+//!   and send-direction interop with C++ peers may not match until full IDL
+//!   hashing lands.
+//!
+//! The table values are taken from observed `rmw_zenoh` traffic / the design
+//! examples and are covered by a test so drift is caught.
+
+/// Wildcard used in the type-hash slot of a *receiver's* key expression so it
+/// matches publishers/clients of any hash. A single-chunk `*` matches exactly
+/// one key-expression chunk (the hash), which is what we want here.
+pub const WILDCARD: &str = "*";
+
+/// Look up the REP-2016 type hash for a DDS-form type name
+/// (e.g. `std_msgs::msg::dds_::String_`).
+///
+/// Returns `None` for types not in the table; callers then fall back to a
+/// wildcard/placeholder for the send direction.
+pub fn known_type_hash(dds_type_name: &str) -> Option<&'static str> {
+  Some(match dds_type_name {
+    "std_msgs::msg::dds_::String_" => {
+      "RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18"
+    }
+    "example_interfaces::srv::dds_::AddTwoInts_" => {
+      "RIHS01_e118de6bf5eeb66a2491b5bda11202e7b68f198d6f67922cf30364858239c81a"
+    }
+    _ => return None,
+  })
+}
+
+/// The hash to place in a *sender's* key: the known hash if we have it,
+/// otherwise a placeholder wildcard (documented limitation).
+pub fn sender_hash(dds_type_name: &str) -> &str {
+  known_type_hash(dds_type_name).unwrap_or(WILDCARD)
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn known_hashes_present() {
+    assert_eq!(
+      known_type_hash("std_msgs::msg::dds_::String_"),
+      Some("RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18")
+    );
+    assert_eq!(
+      known_type_hash("example_interfaces::srv::dds_::AddTwoInts_"),
+      Some("RIHS01_e118de6bf5eeb66a2491b5bda11202e7b68f198d6f67922cf30364858239c81a")
+    );
+  }
+
+  #[test]
+  fn unknown_falls_back_to_wildcard() {
+    assert_eq!(known_type_hash("pkg::msg::dds_::Nope_"), None);
+    assert_eq!(sender_hash("pkg::msg::dds_::Nope_"), WILDCARD);
+    assert!(sender_hash("std_msgs::msg::dds_::String_").starts_with("RIHS01_"));
+  }
+}

--- a/tests/pub_and_sub.rs
+++ b/tests/pub_and_sub.rs
@@ -78,10 +78,14 @@ async fn make_publisher() {
 
   // send messages every 0.25 seconds
   loop {
-    publisher
-      .async_publish("hello subscriber!".into())
-      .await
-      .unwrap();
+    // A Reliable writer can legitimately return `WouldBlock` on the first
+    // attempts, before a matching subscription has been discovered (a
+    // discovery race that shows up on fast/loopback CI runners). Tolerate it
+    // and keep trying; the subscriber only needs one message to arrive within
+    // its timeout.
+    if let Err(e) = publisher.async_publish("hello subscriber!".into()).await {
+      eprintln!("Publish not ready yet, retrying: {e:?}");
+    }
 
     tokio::time::sleep(Duration::from_millis(250)).await;
   }


### PR DESCRIPTION
Introduced flags to select `zenoh` or `dds` as the RMW.
DDS route mainly unchanged.
Zenoh route tested with official ROS 2 tools.
Closes #71 
Supersedes #72 (was coming from `semio-ai:master`, but it was a moving branch)